### PR TITLE
Test fread return value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
+*.exe
+*~
 test-openssl
 tests

--- a/rand.c
+++ b/rand.c
@@ -22,6 +22,7 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 
 #include "rand.h"
 
@@ -35,11 +36,14 @@ void init_rand(void)
 uint32_t random32(void)
 {
 	uint32_t r;
-	fread(&r, 1, sizeof(r), f);
+	size_t len = sizeof(r);
+	size_t len_read = fread(&r, 1, len, f);
+	assert(len_read == len);
 	return r;
 }
 
-void random_buffer(uint8_t *buf, uint32_t len)
+void random_buffer(uint8_t *buf, size_t len)
 {
-	fread(buf, 1, len, f);
+	size_t len_read = fread(buf, 1, len, f);
+	assert(len_read == len);
 }

--- a/rand.h
+++ b/rand.h
@@ -28,6 +28,6 @@
 
 void init_rand(void);
 uint32_t random32(void);
-void random_buffer(uint8_t *buf, uint32_t len);
+void random_buffer(uint8_t *buf, size_t len);
 
 #endif


### PR DESCRIPTION
Ignoring the fread return value triggers warnings at high warning levels. It's also a bad idea in general to assume that reads always succeed, though admittedly fewer things could go wrong when reading from a kernel device. I still much prefer that all code build clean at the strictest warning levels, however.

Discussion:

This patch attempts to be minimal by simply asserting that all bytes requested were read and perhaps should be revised before merging. For embedded work it would be better to report an error condition (maybe after a re-try?) rather than assert()-ing (this will likely be necessary for our project, as crashing would be unacceptable), but that would be a more invasive change and might require a cascade of changes to the calling functions to report errors as well. I would prefer more extensive error checking/reporting in general, but I don't know how that fits in with your vision for the library.

Are you willing to consider a larger patch to add some error reporting up the call tree? If so, do you have a library policy for how errors are reported? I see that generate_k_rfc6979() returns an error code, so I suspect you prefer that style to adding an error code parameter when the function does not already have a return value.

Minor changes:

size_t is the right type for an array count. I also added VIM backup files and Windows executables to .gitignore.
