### PR TITLE
Make CMakeLists.txt build tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,13 @@ if(MSVC)
   set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
 endif(MSVC)
 add_library(TrezorCrypto STATIC ${SOURCES})
+
+# disable sequence point warning because of AES code
+set(CMAKE_C_FLAGS       "${CMAKE_C_FLAGS} -Wno-sequence-point")
+add_executable(tests tests.c aescrypt.c aeskey.c aestab.c aes_modes.c)
+target_link_libraries(tests TrezorCrypto check rt pthread m crypto)
+add_test(NAME trezor-crypto COMMAND tests)
+
+add_executable(test-openssl test-openssl.c)
+target_link_libraries(test-openssl TrezorCrypto check rt pthread m crypto)
+add_test(NAME trezor-crypto-openssl COMMAND test-openssl 100)

--- a/test-openssl.c
+++ b/test-openssl.c
@@ -30,7 +30,7 @@
 #include "ecdsa.h"
 #include "rand.h"
 
-int main(void)
+int main(int argc, char *argv[])
 {
 	uint8_t sig[64], pub_key33[33], pub_key65[65], priv_key[32], msg[256], buffer[1000], hash[32], *p;
 	uint32_t i, j, msg_len;
@@ -41,7 +41,14 @@ int main(void)
 	init_rand();
 	ecgroup = EC_GROUP_new_by_curve_name(NID_secp256k1);
 
-	for (;;) {
+	unsigned long max_iterations = -1;
+	if (argc == 2) {
+		sscanf(argv[1], "%lu", &max_iterations);
+	} else if (argc > 2) {
+		puts("Zero or one command-line arguments only, exiting....");
+	}
+	unsigned long iterations = 0;
+	while (argc == 1 || iterations < max_iterations) {
 		// random message len between 1 and 256
 		msg_len = (random32() & 0xFF) + 1;
 		// create random message
@@ -113,6 +120,7 @@ int main(void)
 		EC_KEY_free(eckey);
 		cnt++;
 		if ((cnt % 100) == 0) printf("Passed ... %d\n", cnt);
+            ++iterations;
 	}
 	EC_GROUP_free(ecgroup);
 	return 0;

--- a/tests.c
+++ b/tests.c
@@ -54,7 +54,7 @@ uint8_t *fromhex(const char *str)
 	return buf;
 }
 
-inline char *tohex(const uint8_t *bin, size_t l)
+char *tohex(const uint8_t *bin, size_t l)
 {
 	char *buf = (char *)malloc(l * 2 + 1);
 	static char digits[] = "0123456789abcdef";


### PR DESCRIPTION
I have my trezor-crypto repo in a subdirectory of my main project; it builds very well with just an add_directory(trezor-crypto), which was probably intended. The only problem is that CMake can't pick up the trezor-crypto tests. This patch solves that problem by adding the executables with add_test() and screening out the sequence-point flag that breaks the aes code. The openssl test doesn't terminate and so isn't suitable for running automatically, so I also added an optional command-line switch used when CMake runs the test to specify the number of iterations. Now you can just do 'make test' at the top level and have trezor-crypto's tests run along with all the others.

The other small change (which maybe should have been a different patch, sorry) is removing 'inline' from to-hex. At high warning levels GCC doesn't like inline functions with static data, so this was necessary to make the build clean, and it's the Right Thing to do.
