### PR TITLE
Finalize all open file descriptors

### DIFF
--- a/rand.c
+++ b/rand.c
@@ -33,10 +33,12 @@ void init_rand(void)
 	f = fopen("/dev/urandom", "r");
 }
 
-void finalize_rand(void)
+int finalize_rand(void)
 {
-    fclose(f);
+    int err = fclose(f);
     f = NULL;
+
+    return err;
 }
 
 uint32_t random32(void)

--- a/rand.c
+++ b/rand.c
@@ -33,6 +33,12 @@ void init_rand(void)
 	f = fopen("/dev/urandom", "r");
 }
 
+void finalize_rand(void)
+{
+    fclose(f);
+    f = NULL;
+}
+
 uint32_t random32(void)
 {
 	uint32_t r;

--- a/rand.h
+++ b/rand.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 void init_rand(void);
-void finalize_rand(void);
+int finalize_rand(void);
 uint32_t random32(void);
 void random_buffer(uint8_t *buf, size_t len);
 

--- a/rand.h
+++ b/rand.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 void init_rand(void);
+void finalize_rand(void);
 uint32_t random32(void);
 void random_buffer(uint8_t *buf, size_t len);
 


### PR DESCRIPTION
Hi,

I've been carrying some patches I haven't had time to clean up and offer upstream, and I need to do something about that. This one is easy and non-invasive, just a trivial patch to allow a program to close the /dev/urandom file descriptor. The reason for this is that valgrind detects the open resource and thinks it's a leak even though it obviously isn't, and I like to keep the output of my test tools very clean so that any new problems jump out at me--otherwise I might miss them among the "expected failures."