### PR TITLE
Fix RFC6979 generation of k.

### DIFF
--- a/ecdsa.c
+++ b/ecdsa.c
@@ -256,7 +256,7 @@ int generate_k_random(bignum256 *k) {
 int generate_k_rfc6979(bignum256 *secret, const uint8_t *priv_key, const uint8_t *hash)
 {
 	int i;
-	uint8_t v[32], k[32], bx[2*32], buf[32 + 1 + sizeof(bx)], t[32];
+	uint8_t v[32], k[32], bx[2*32], buf[32 + 1 + sizeof(bx)];
 	bignum256 z1;
 
 	memcpy(bx, priv_key, 32);
@@ -280,8 +280,8 @@ int generate_k_rfc6979(bignum256 *secret, const uint8_t *priv_key, const uint8_t
 	hmac_sha256(k, sizeof(k), v, sizeof(k), v);
 
 	for (i = 0; i < 10000; i++) {
-		hmac_sha256(k, sizeof(k), v, sizeof(v), t);
-		bn_read_be(t, secret);
+		hmac_sha256(k, sizeof(k), v, sizeof(v), v);
+		bn_read_be(v, secret);
 		if ( !bn_is_zero(secret) && bn_is_less(secret, &order256k1) ) {
 			return 0; // good number -> no error
 		}


### PR DESCRIPTION
The standard says:
step h:
```
  Set T to the empty sequence.
  while tlen < qlen
      V = HMAC_K(V)
      T = T || V
  k = bits2int(T)
```

in this case (HMAC-SHA256, qlen=256bit) this simplifies to
```
  V = HMAC_K(V)
  T = V
  k = bits2int(T)
```
and T can be omitted.

The old code (wrong) did:
```
  T = HMAC_K(V)
  k = bits2int(T)
```
Note that V will only be used again if the first k is out of range.
Thus, the old code produced the right result with a very high probability.

*Disclaimer*: I didn't test this.  It is infeasible to write a test that triggers the case this patch fixes without changing the API (or completely breaking HMAC-SHA256). The existing tests still pass:
```
tests.c:495:P:rfc6979:test_rfc6979:0: Passed
```

*Note*: The code doesn't handle the case where r or s in the signature get 0 (probability for this is about 3 in 2^256).  In this case the sign function would just return an error instead of trying the next k value.  Fixing this would also require an API change.