### PR TITLE
Make word list const

### DIFF
--- a/bip39.c
+++ b/bip39.c
@@ -155,7 +155,7 @@ void mnemonic_to_seed(const char *mnemonic, const char *passphrase, uint8_t seed
 	pbkdf2_hmac_sha512((const uint8_t *)mnemonic, strlen(mnemonic), salt, saltlen, BIP39_PBKDF2_ROUNDS, seed, 512 / 8, progress_callback);
 }
 
-const char **mnemonic_wordlist(void)
+const char * const *mnemonic_wordlist(void)
 {
 	return wordlist;
 }

--- a/bip39.h
+++ b/bip39.h
@@ -36,6 +36,6 @@ int mnemonic_check(const char *mnemonic);
 
 void mnemonic_to_seed(const char *mnemonic, const char *passphrase, uint8_t seed[512 / 8], void (*progress_callback)(uint32_t current, uint32_t total));
 
-const char **mnemonic_wordlist(void);
+const char * const *mnemonic_wordlist(void);
 
 #endif

--- a/bip39_english.h
+++ b/bip39_english.h
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const char *wordlist[] = {
+const char * const wordlist[] = {
 "abandon",
 "ability",
 "able",


### PR DESCRIPTION
This makes the pointers to the words constant.  It moves 8kb from ram
to flash and also prevents them from accidental corruption.  It changes
the return type of mnemonic_wordlist() to reflect this change.  Everyone 
calling it should also change the type to `const char * const *`.

This means trezor-mcu requires a trivial change. 
Just replace `const char** wl` with `const char * const * wl` twice in `recovery.c`.