### PR TITLE
Off by one error in word length.

### DIFF
--- a/bip39.c
+++ b/bip39.c
@@ -103,7 +103,7 @@ int mnemonic_check(const char *mnemonic)
 	while (mnemonic[i]) {
 		j = 0;
 		while (mnemonic[i] != ' ' && mnemonic[i] != 0) {
-			if (j >= sizeof(current_word)) {
+			if (j >= sizeof(current_word) - 1) {
 				return 0;
 			}
 			current_word[j] = mnemonic[i];
@@ -145,6 +145,7 @@ int mnemonic_check(const char *mnemonic)
 	return 0;
 }
 
+// passphrase must be at most 256 characters or code may crash
 void mnemonic_to_seed(const char *mnemonic, const char *passphrase, uint8_t seed[512 / 8], void (*progress_callback)(uint32_t current, uint32_t total))
 {
 	uint8_t salt[8 + 256 + 4];

--- a/bip39.h
+++ b/bip39.h
@@ -34,6 +34,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len);
 
 int mnemonic_check(const char *mnemonic);
 
+// passphrase must be at most 256 characters or code may crash
 void mnemonic_to_seed(const char *mnemonic, const char *passphrase, uint8_t seed[512 / 8], void (*progress_callback)(uint32_t current, uint32_t total));
 
 const char * const *mnemonic_wordlist(void);


### PR DESCRIPTION
This could lead to a buffer overrun if the final 0 byte is written to `current_word[j]` after the loop.

Also document the limit of passphrase in mnemonic_to_seed.