### PR TITLE
Fixed issues with Python files

### DIFF
--- a/TrezorCrypto.pyx
+++ b/TrezorCrypto.pyx
@@ -1,5 +1,6 @@
 cimport c
 cimport cython
+
 cdef class HDNode:
 
 	cdef c.HDNode node

--- a/TrezorCrypto.pyx
+++ b/TrezorCrypto.pyx
@@ -1,6 +1,5 @@
 cimport c
 cimport cython
-
 cdef class HDNode:
 
 	cdef c.HDNode node
@@ -34,7 +33,7 @@ cdef class HDNode:
 		c.hdnode_public_ckd(cython.address(x.node), i)
 		return x
 
-	def private_ckd(self, int i):
+	def private_ckd(self, unsigned int i):
 		x = HDNode(copyfrom=self)
 		c.hdnode_private_ckd(cython.address(x.node), i)
 		return x

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 
 srcs = [
+    'nist256p1',
 	'base58',
 	'bignum',
 	'bip32',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 
 srcs = [
-    'nist256p1',
+	'nist256p1',
 	'base58',
 	'bignum',
 	'bip32',


### PR DESCRIPTION
I found two bugs while trying to compile Trezor Crypto using Cython. 

1. If I attempted a private CKD using a hardened index in Python, it caused an integer overflow error due to the size difference between signed Python and C integers.

2. The setup.py file was missing an import for the nist256p1.c file. 