### PR TITLE
Extended comments, new function bn_add, a bug fix.

### DIFF
--- a/bignum.h
+++ b/bignum.h
@@ -53,8 +53,6 @@ int bn_is_equal(const bignum256 *a, const bignum256 *b);
 
 void bn_cmov(bignum256 *res, int cond, const bignum256 *truecase, const bignum256 *falsecase);
 
-int bn_bitlen(const bignum256 *a);
-
 void bn_lshift(bignum256 *a);
 
 void bn_rshift(bignum256 *a);
@@ -74,6 +72,8 @@ void bn_sqrt(bignum256 *x, const bignum256 *prime);
 void bn_inverse(bignum256 *x, const bignum256 *prime);
 
 void bn_normalize(bignum256 *a);
+
+void bn_add(bignum256 *a, const bignum256 *b);
 
 void bn_addmod(bignum256 *a, const bignum256 *b, const bignum256 *prime);
 

--- a/bip32.c
+++ b/bip32.c
@@ -143,6 +143,7 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
 	}
 	if (!failed) {
 		bn_addmod(&a, &b, &default_curve->order);
+		bn_mod(&a, &default_curve->order);
 		if (bn_is_zero(&a)) {
 			failed = true;
 		}


### PR DESCRIPTION
This contains some bug fixes, since bn_addmod does no longer a bn_mod.  Otherwise, mainly more documention.


Describe normalized, partly reduced and reduced numbers.
Comment which function expects which kind of input.
Removed unused bn_bitlen.
Add bn_add that does not reduce.
Bug fix in ecdsa_validate_pubkey: bn_mod before bn_is_equal.
Bug fix in hdnode_private_ckd: bn_mod after bn_addmod.