### PR TITLE
bignum: use bn_addi for bignum and scalar addition (instead of bn_subi)

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -763,13 +763,6 @@ void bn_addi(bignum256 *a, uint32_t b) {
 	}
 }
 
-void bn_subi(bignum256 *a, uint32_t b, const bignum256 *prime) {
-	assert (b <= prime->val[0]);
-	// the possible underflow will be taken care of when adding the prime
-	a->val[0] -= b;
-	bn_add(a, prime);
-}
-
 // res = a - b mod prime.  More exactly res = a + (2*prime - b).
 // b must be a partly reduced number
 // result is normalized but not reduced.

--- a/bignum.h
+++ b/bignum.h
@@ -79,8 +79,6 @@ void bn_addmod(bignum256 *a, const bignum256 *b, const bignum256 *prime);
 
 void bn_addi(bignum256 *a, uint32_t b);
 
-void bn_subi(bignum256 *a, uint32_t b, const bignum256 *prime);
-
 void bn_subtractmod(const bignum256 *a, const bignum256 *b, bignum256 *res, const bignum256 *prime);
 
 void bn_subtract(const bignum256 *a, const bignum256 *b, bignum256 *res);

--- a/ecdsa.c
+++ b/ecdsa.c
@@ -111,7 +111,7 @@ void point_double(const ecdsa_curve *curve, curve_point *cp)
 	xr = cp->x;
 	bn_multiply(&xr, &xr, &curve->prime);
 	bn_mult_k(&xr, 3, &curve->prime);
-	bn_subi(&xr, -curve->a, &curve->prime);
+	bn_addi(&xr, curve->a);
 	bn_multiply(&xr, &lambda, &curve->prime);
 
 	// xr = lambda^2 - 2*x
@@ -864,7 +864,7 @@ void uncompress_coords(const ecdsa_curve *curve, uint8_t odd, const bignum256 *x
 	// y^2 = x^3 + 0*x + 7
 	memcpy(y, x, sizeof(bignum256));         // y is x
 	bn_multiply(x, y, &curve->prime);        // y is x^2
-	bn_subi(y, -curve->a, &curve->prime);    // y is x^2 + a
+	bn_addi(y, curve->a);                    // y is x^2 + a
 	bn_multiply(x, y, &curve->prime);        // y is x^3 + ax
 	bn_add(y, &curve->b);                    // y is x^3 + ax + b
 	bn_sqrt(y, &curve->prime);               // y = sqrt(y)
@@ -915,7 +915,7 @@ int ecdsa_validate_pubkey(const ecdsa_curve *curve, const curve_point *pub)
 
 	// x^3 + ax + b
 	bn_multiply(&(pub->x), &x3_ax_b, &curve->prime);  // x^2
-	bn_subi(&x3_ax_b, -curve->a, &curve->prime);      // x^2 + a
+	bn_addi(&x3_ax_b, curve->a);                      // x^2 + a
 	bn_multiply(&(pub->x), &x3_ax_b, &curve->prime);  // x^3 + ax
 	bn_addmod(&x3_ax_b, &curve->b, &curve->prime);    // x^3 + ax + b
 	bn_mod(&x3_ax_b, &curve->prime);


### PR DESCRIPTION
`bn_subi()` was used only for adding `curve->a`, by subtracting `-curve->a` from a 256-bit number.
The current version should be a bit more readable, by using `bn_addi()` instead.