### PR TITLE
Add generated dependency files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.d
 *.exe
 *~
 test-openssl


### PR DESCRIPTION
trezor/trezor-mcu#104 refactors the Makefile to use dependency files.
Because this repository does not ignore these files, git marks the
submodule as dirty.