### PR TITLE
Bignum: add tests and support little endian mode

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Jochen Hoenicke <hoenicke@gmail.com>
 Dustin Laurence <dustin@laurences.net>
 Ondrej Mikle <ondrej.mikle@nic.cz>
 Roman Zeyde <roman.zeyde@gmail.com>
+Alex Beregszaszi <alex@rtfs.hu>
 netanelkl <netanel.keidar@gmail.com>
 Jan Pochyla <jpochyla@gmail.com>
 Ondrej Mikle <ondrej.mikle@gmail.com>

--- a/bignum.c
+++ b/bignum.c
@@ -182,6 +182,19 @@ void bn_read_uint64(uint64_t in_number, bignum256 *out_number)
 	out_number->val[8] = 0;
 }
 
+// a must be normalized
+int bn_bitcount(const bignum256 *a)
+{
+	int i;
+	for (i = 8; i >= 0; i--) {
+		int tmp = a->val[i];
+		if (tmp != 0) {
+			return i * 30 + (32 - __builtin_clz(tmp));
+		}
+	}
+	return 0;
+}
+
 // sets a bignum to zero.
 void bn_zero(bignum256 *a)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -156,6 +156,32 @@ void bn_write_le(const bignum256 *in_number, uint8_t *out_number)
 	}
 }
 
+void bn_load_uint32(uint32_t in_number, bignum256 *out_number)
+{
+	out_number->val[0] = in_number & 0x3FFFFFFF;
+	out_number->val[1] = in_number >> 30;
+	out_number->val[2] = 0;
+	out_number->val[3] = 0;
+	out_number->val[4] = 0;
+	out_number->val[5] = 0;
+	out_number->val[6] = 0;
+	out_number->val[7] = 0;
+	out_number->val[8] = 0;
+}
+
+void bn_load_uint64(uint64_t in_number, bignum256 *out_number)
+{
+	out_number->val[0] = in_number & 0x3FFFFFFF;
+	out_number->val[1] = (in_number >>= 30) & 0x3FFFFFFF;
+	out_number->val[2] = in_number >>= 30;
+	out_number->val[3] = 0;
+	out_number->val[4] = 0;
+	out_number->val[5] = 0;
+	out_number->val[6] = 0;
+	out_number->val[7] = 0;
+	out_number->val[8] = 0;
+}
+
 // copies number a to b
 void bn_copy(bignum256 *a, bignum256 *b)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -156,6 +156,15 @@ void bn_write_le(const bignum256 *in_number, uint8_t *out_number)
 	}
 }
 
+// copies number a to b
+void bn_copy(bignum256 *a, bignum256 *b)
+{
+	int i;
+	for (i = 0; i < 9; i++) {
+		b->val[i] = a->val[i];
+	}
+}
+
 // sets a bignum to zero.
 void bn_zero(bignum256 *a)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -182,15 +182,6 @@ void bn_load_uint64(uint64_t in_number, bignum256 *out_number)
 	out_number->val[8] = 0;
 }
 
-// copies number a to b
-void bn_copy(bignum256 *a, bignum256 *b)
-{
-	int i;
-	for (i = 0; i < 9; i++) {
-		b->val[i] = a->val[i];
-	}
-}
-
 // sets a bignum to zero.
 void bn_zero(bignum256 *a)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -156,7 +156,7 @@ void bn_write_le(const bignum256 *in_number, uint8_t *out_number)
 	}
 }
 
-void bn_load_uint32(uint32_t in_number, bignum256 *out_number)
+void bn_read_uint32(uint32_t in_number, bignum256 *out_number)
 {
 	out_number->val[0] = in_number & 0x3FFFFFFF;
 	out_number->val[1] = in_number >> 30;
@@ -169,7 +169,7 @@ void bn_load_uint32(uint32_t in_number, bignum256 *out_number)
 	out_number->val[8] = 0;
 }
 
-void bn_load_uint64(uint64_t in_number, bignum256 *out_number)
+void bn_read_uint64(uint64_t in_number, bignum256 *out_number)
 {
 	out_number->val[0] = in_number & 0x3FFFFFFF;
 	out_number->val[1] = (in_number >>= 30) & 0x3FFFFFFF;

--- a/bignum.c
+++ b/bignum.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2014 Tomas Dzetkulic
  * Copyright (c) 2013-2014 Pavol Rusnak
  * Copyright (c)      2015 Jochen Hoenicke
+ * Copyright (c)      2016 Alex Beregszaszi
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
@@ -69,6 +70,22 @@ inline void write_be(uint8_t *data, uint32_t x)
 	data[3] = x;
 }
 
+inline uint32_t read_le(const uint8_t *data)
+{
+	return (((uint32_t)data[3]) << 24) |
+	       (((uint32_t)data[2]) << 16) |
+	       (((uint32_t)data[1]) << 8)  |
+	       (((uint32_t)data[0]));
+}
+
+inline void write_le(uint8_t *data, uint32_t x)
+{
+	data[3] = x >> 24;
+	data[2] = x >> 16;
+	data[1] = x >> 8;
+	data[0] = x;
+}
+
 // convert a raw bigendian 256 bit value into a normalized bignum.
 // out_number is partly reduced (since it fits in 256 bit).
 void bn_read_be(const uint8_t *in_number, bignum256 *out_number)
@@ -100,6 +117,41 @@ void bn_write_be(const bignum256 *in_number, uint8_t *out_number)
 		uint32_t limb = in_number->val[7 - i];
 		temp |= limb >> (14 - 2*i);
 		write_be(out_number + i * 4, temp);
+		temp = limb << (18 + 2*i);
+	}
+}
+
+// convert a raw little endian 256 bit value into a normalized bignum.
+// out_number is partly reduced (since it fits in 256 bit).
+void bn_read_le(const uint8_t *in_number, bignum256 *out_number)
+{
+	int i;
+	uint32_t temp = 0;
+	for (i = 0; i < 8; i++) {
+		// invariant: temp = (in_number % 2^(32i)) >> 30i
+		// get next limb = (in_number % 2^(32(i+1))) >> 32i
+		uint32_t limb = read_le(in_number + i * 4);
+		// temp = (in_number % 2^(32(i+1))) << 30i
+		temp |= limb << (2*i);
+		// store 30 bits into val[i]
+		out_number->val[i]= temp & 0x3FFFFFFF;
+		// prepare temp for next round
+		temp = limb >> (30 - 2*i);
+	}
+	out_number->val[8] = temp;
+}
+
+// convert a normalized bignum to a raw little endian 256 bit number.
+// in_number must be fully reduced.
+void bn_write_le(const bignum256 *in_number, uint8_t *out_number)
+{
+	int i;
+	uint32_t temp = in_number->val[8] << 16;
+	for (i = 0; i < 8; i++) {
+		// invariant: temp = (in_number >> 30*(8-i)) << (16 + 2i)
+		uint32_t limb = in_number->val[7 - i];
+		temp |= limb >> (14 - 2*i);
+		write_le(out_number + (7 - i) * 4, temp);
 		temp = limb << (18 + 2*i);
 	}
 }

--- a/bignum.h
+++ b/bignum.h
@@ -54,6 +54,10 @@ void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
 
 void bn_write_le(const bignum256 *in_number, uint8_t *out_number);
 
+void bn_load_uint32(uint32_t in_number, bignum256 *out_number);
+
+void bn_load_uint64(uint64_t in_number, bignum256 *out_number);
+
 void bn_copy(bignum256 *a, bignum256 *b);
 
 void bn_zero(bignum256 *a);

--- a/bignum.h
+++ b/bignum.h
@@ -53,6 +53,8 @@ void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
 
 void bn_write_le(const bignum256 *in_number, uint8_t *out_number);
 
+void bn_copy(bignum256 *a, bignum256 *b);
+
 void bn_zero(bignum256 *a);
 
 int bn_is_zero(const bignum256 *a);

--- a/bignum.h
+++ b/bignum.h
@@ -54,9 +54,9 @@ void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
 
 void bn_write_le(const bignum256 *in_number, uint8_t *out_number);
 
-void bn_load_uint32(uint32_t in_number, bignum256 *out_number);
+void bn_read_uint32(uint32_t in_number, bignum256 *out_number);
 
-void bn_load_uint64(uint64_t in_number, bignum256 *out_number);
+void bn_read_uint64(uint64_t in_number, bignum256 *out_number);
 
 // copies number a to b
 static inline void bn_copy(const bignum256 *a, bignum256 *b) {

--- a/bignum.h
+++ b/bignum.h
@@ -39,9 +39,19 @@ uint32_t read_be(const uint8_t *data);
 // write 4 big endian bytes
 void write_be(uint8_t *data, uint32_t x);
 
+// read 4 little endian bytes into uint32
+uint32_t read_le(const uint8_t *data);
+
+// write 4 little endian bytes
+void write_le(uint8_t *data, uint32_t x);
+
 void bn_read_be(const uint8_t *in_number, bignum256 *out_number);
 
 void bn_write_be(const bignum256 *in_number, uint8_t *out_number);
+
+void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
+
+void bn_write_le(const bignum256 *in_number, uint8_t *out_number);
 
 void bn_zero(bignum256 *a);
 

--- a/bignum.h
+++ b/bignum.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2013-2014 Tomas Dzetkulic
  * Copyright (c) 2013-2014 Pavol Rusnak
+ * Copyright (c) 2016 Alex Beregszaszi
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
@@ -58,6 +59,14 @@ void bn_copy(bignum256 *a, bignum256 *b);
 void bn_zero(bignum256 *a);
 
 int bn_is_zero(const bignum256 *a);
+
+static inline int bn_is_even(const bignum256 *a) {
+	return (a->val[0] & 1) == 0;
+}
+
+static inline int bn_is_odd(const bignum256 *a) {
+	return (a->val[0] & 1) == 1;
+}
 
 int bn_is_less(const bignum256 *a, const bignum256 *b);
 

--- a/bignum.h
+++ b/bignum.h
@@ -58,6 +58,22 @@ void bn_read_uint32(uint32_t in_number, bignum256 *out_number);
 
 void bn_read_uint64(uint64_t in_number, bignum256 *out_number);
 
+static inline uint32_t bn_write_uint32(const bignum256 *in_number)
+{
+	return in_number->val[0] | (in_number->val[1] << 30);
+}
+
+static inline uint64_t bn_write_uint64(const bignum256 *in_number)
+{
+	uint64_t tmp;
+	tmp = in_number->val[2];
+	tmp <<= 30;
+	tmp |= in_number->val[1];
+	tmp <<= 30;
+	tmp |= in_number->val[0];
+	return tmp;
+}
+
 // copies number a to b
 static inline void bn_copy(const bignum256 *a, bignum256 *b) {
 	*b = *a;

--- a/bignum.h
+++ b/bignum.h
@@ -63,6 +63,8 @@ static inline void bn_copy(const bignum256 *a, bignum256 *b) {
 	*b = *a;
 }
 
+int bn_bitcount(const bignum256 *a);
+
 void bn_zero(bignum256 *a);
 
 int bn_is_zero(const bignum256 *a);

--- a/bignum.h
+++ b/bignum.h
@@ -58,7 +58,10 @@ void bn_load_uint32(uint32_t in_number, bignum256 *out_number);
 
 void bn_load_uint64(uint64_t in_number, bignum256 *out_number);
 
-void bn_copy(bignum256 *a, bignum256 *b);
+// copies number a to b
+static inline void bn_copy(const bignum256 *a, bignum256 *b) {
+	*b = *a;
+}
 
 void bn_zero(bignum256 *a);
 

--- a/tests.c
+++ b/tests.c
@@ -233,6 +233,46 @@ START_TEST(test_bignum_read_uint64)
 }
 END_TEST
 
+START_TEST(test_bignum_write_uint32)
+{
+	bignum256 a;
+
+	// lowest 30 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
+	ck_assert_int_eq(bn_write_uint32(&a), 0x3fffffff);
+
+	// bit 31 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
+	ck_assert_int_eq(bn_write_uint32(&a), 0x40000000);
+}
+END_TEST
+
+START_TEST(test_bignum_write_uint64)
+{
+	bignum256 a;
+
+	// lowest 30 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
+	ck_assert_int_eq(bn_write_uint64(&a), 0x3fffffff);
+
+	// bit 31 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
+	ck_assert_int_eq(bn_write_uint64(&a), 0x40000000);
+
+	// bit 33 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000100000000"), &a);
+	ck_assert_int_eq(bn_write_uint64(&a), 0x100000000LL);
+
+	// bit 61 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000002000000000000000"), &a);
+	ck_assert_int_eq(bn_write_uint64(&a), 0x2000000000000000LL);
+
+	// all 64 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000ffffffffffffffff"), &a);
+	ck_assert_int_eq(bn_write_uint64(&a), 0xffffffffffffffffLL);
+}
+END_TEST
+
 START_TEST(test_bignum_copy)
 {
 	bignum256 a;
@@ -2547,6 +2587,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_write_le);
 	tcase_add_test(tc, test_bignum_read_uint32);
 	tcase_add_test(tc, test_bignum_read_uint64);
+	tcase_add_test(tc, test_bignum_write_uint32);
+	tcase_add_test(tc, test_bignum_write_uint64);
 	tcase_add_test(tc, test_bignum_copy);
 	tcase_add_test(tc, test_bignum_is_even);
 	tcase_add_test(tc, test_bignum_is_odd);

--- a/tests.c
+++ b/tests.c
@@ -100,6 +100,17 @@ START_TEST(test_bignum_read_be)
 }
 END_TEST
 
+START_TEST(test_bignum_write_be)
+{
+	bignum256 a = { { 0x286d8bd5, 0x380c7c17, 0x3c6a2ec1, 0x2d787ef5, 0x14437cd3, 0x25a043f8, 0x1dd5263f, 0x33a162c3, 0x0000c55e } };
+	uint8_t tmp[32];
+
+	bn_write_be(&a, tmp);
+
+	ck_assert_mem_eq(tmp, fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), 32);
+}
+END_TEST
+
 
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
@@ -2347,6 +2358,7 @@ Suite *test_suite(void)
 
 	tc = tcase_create("bignum");
 	tcase_add_test(tc, test_bignum_read_be);
+	tcase_add_test(tc, test_bignum_write_be);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -165,6 +165,36 @@ START_TEST(test_bignum_copy)
 }
 END_TEST
 
+START_TEST(test_bignum_is_even)
+{
+	bignum256 a;
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), &a);
+	ck_assert_int_eq(bn_is_even(&a), 0);
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd2"), &a);
+	ck_assert_int_eq(bn_is_even(&a), 1);
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd0"), &a);
+	ck_assert_int_eq(bn_is_even(&a), 1);
+}
+END_TEST
+
+START_TEST(test_bignum_is_odd)
+{
+	bignum256 a;
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), &a);
+	ck_assert_int_eq(bn_is_odd(&a), 1);
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd2"), &a);
+	ck_assert_int_eq(bn_is_odd(&a), 0);
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd0"), &a);
+	ck_assert_int_eq(bn_is_odd(&a), 0);
+}
+END_TEST
+
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
 {
@@ -2416,6 +2446,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_read_le);
 	tcase_add_test(tc, test_bignum_write_le);
 	tcase_add_test(tc, test_bignum_copy);
+	tcase_add_test(tc, test_bignum_is_even);
+	tcase_add_test(tc, test_bignum_is_odd);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -153,6 +153,18 @@ START_TEST(test_bignum_write_le)
 }
 END_TEST
 
+START_TEST(test_bignum_copy)
+{
+	bignum256 a;
+	bignum256 b;
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), &a);
+	bn_copy(&a, &b);
+
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
 {
@@ -2403,6 +2415,7 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_equal);
 	tcase_add_test(tc, test_bignum_read_le);
 	tcase_add_test(tc, test_bignum_write_le);
+	tcase_add_test(tc, test_bignum_copy);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -83,6 +83,24 @@ char *tohex(const uint8_t *bin, size_t l)
 #define ck_assert_mem_eq(X, Y, L) _ck_assert_mem(X, Y, L, ==)
 #define ck_assert_mem_ne(X, Y, L) _ck_assert_mem(X, Y, L, !=)
 
+START_TEST(test_bignum_read_be)
+{
+	bignum256 a;
+	uint8_t input[32];
+
+	memcpy(input, fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), 32);
+
+	bn_read_be(input, &a);
+
+	bignum256 b = { { 0x286d8bd5, 0x380c7c17, 0x3c6a2ec1, 0x2d787ef5, 0x14437cd3, 0x25a043f8, 0x1dd5263f, 0x33a162c3, 0x0000c55e } };
+
+	for (int i = 0; i < 9; i++) {
+		ck_assert_int_eq(a.val[i], b.val[i]);
+	}
+}
+END_TEST
+
+
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
 {
@@ -2326,6 +2344,10 @@ Suite *test_suite(void)
 {
 	Suite *s = suite_create("trezor-crypto");
 	TCase *tc;
+
+	tc = tcase_create("bignum");
+	tcase_add_test(tc, test_bignum_read_be);
+	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");
 	tcase_add_test(tc, test_base58);

--- a/tests.c
+++ b/tests.c
@@ -123,6 +123,36 @@ START_TEST(test_bignum_equal)
 }
 END_TEST
 
+START_TEST(test_bignum_read_le)
+{
+	bignum256 a;
+	bignum256 b;
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), &a);
+	bn_read_le(fromhex("d58b6de8051f031eeca2c6d7fbe1b5d37c4314fe1068f96352dd0d8b85ce5ec5"), &b);
+
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
+START_TEST(test_bignum_write_le)
+{
+	bignum256 a;
+	bignum256 b;
+	uint8_t tmp[32];
+
+	bn_read_be(fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), &a);
+	bn_write_le(&a, tmp);
+
+	bn_read_le(tmp, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	bn_read_be(fromhex("d58b6de8051f031eeca2c6d7fbe1b5d37c4314fe1068f96352dd0d8b85ce5ec5"), &a);
+	bn_read_be(tmp, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
 {
@@ -2371,6 +2401,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_read_be);
 	tcase_add_test(tc, test_bignum_write_be);
 	tcase_add_test(tc, test_bignum_equal);
+	tcase_add_test(tc, test_bignum_read_le);
+	tcase_add_test(tc, test_bignum_write_le);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -111,6 +111,17 @@ START_TEST(test_bignum_write_be)
 }
 END_TEST
 
+START_TEST(test_bignum_equal)
+{
+	bignum256 a = { { 0x286d8bd5, 0x380c7c17, 0x3c6a2ec1, 0x2d787ef5, 0x14437cd3, 0x25a043f8, 0x1dd5263f, 0x33a162c3, 0x0000c55e } };
+	bignum256 b = { { 0x286d8bd5, 0x380c7c17, 0x3c6a2ec1, 0x2d787ef5, 0x14437cd3, 0x25a043f8, 0x1dd5263f, 0x33a162c3, 0x0000c55e } };
+	bignum256 c = { { 0, } };
+
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+	ck_assert_int_eq(bn_is_equal(&c, &c), 1);
+	ck_assert_int_eq(bn_is_equal(&a, &c), 0);
+}
+END_TEST
 
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
@@ -2359,6 +2370,7 @@ Suite *test_suite(void)
 	tc = tcase_create("bignum");
 	tcase_add_test(tc, test_bignum_read_be);
 	tcase_add_test(tc, test_bignum_write_be);
+	tcase_add_test(tc, test_bignum_equal);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -123,6 +123,36 @@ START_TEST(test_bignum_equal)
 }
 END_TEST
 
+START_TEST(test_bignum_zero)
+{
+	bignum256 a;
+	bignum256 b;
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
+	bn_zero(&b);
+
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
+START_TEST(test_bignum_is_zero)
+{
+	bignum256 a;
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
+	ck_assert_int_eq(bn_is_zero(&a), 1);
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000001"), &a);
+	ck_assert_int_eq(bn_is_zero(&a), 0);
+
+	bn_read_be(fromhex("1000000000000000000000000000000000000000000000000000000000000000"), &a);
+	ck_assert_int_eq(bn_is_zero(&a), 0);
+
+	bn_read_be(fromhex("f000000000000000000000000000000000000000000000000000000000000000"), &a);
+	ck_assert_int_eq(bn_is_zero(&a), 0);
+}
+END_TEST
+
 START_TEST(test_bignum_read_le)
 {
 	bignum256 a;
@@ -2493,6 +2523,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_read_be);
 	tcase_add_test(tc, test_bignum_write_be);
 	tcase_add_test(tc, test_bignum_equal);
+	tcase_add_test(tc, test_bignum_zero);
+	tcase_add_test(tc, test_bignum_is_zero);
 	tcase_add_test(tc, test_bignum_read_le);
 	tcase_add_test(tc, test_bignum_write_le);
 	tcase_add_test(tc, test_bignum_load_uint32);

--- a/tests.c
+++ b/tests.c
@@ -275,6 +275,24 @@ START_TEST(test_bignum_is_odd)
 }
 END_TEST
 
+START_TEST(test_bignum_bitcount)
+{
+	bignum256 a;
+
+	bn_zero(&a);
+	ck_assert_int_eq(bn_bitcount(&a), 0);
+
+	bn_read_uint32(0x3fffffff, &a);
+	ck_assert_int_eq(bn_bitcount(&a), 30);
+
+	bn_read_uint32(0xffffffff, &a);
+	ck_assert_int_eq(bn_bitcount(&a), 32);
+
+	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
+	ck_assert_int_eq(bn_bitcount(&a), 256);
+}
+END_TEST
+
 // from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_keys_valid.json
 START_TEST(test_base58)
 {
@@ -2532,6 +2550,7 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_copy);
 	tcase_add_test(tc, test_bignum_is_even);
 	tcase_add_test(tc, test_bignum_is_odd);
+	tcase_add_test(tc, test_bignum_bitcount);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("base58");

--- a/tests.c
+++ b/tests.c
@@ -183,52 +183,52 @@ START_TEST(test_bignum_write_le)
 }
 END_TEST
 
-START_TEST(test_bignum_load_uint32)
+START_TEST(test_bignum_read_uint32)
 {
 	bignum256 a;
 	bignum256 b;
 
 	// lowest 30 bits set
 	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
-	bn_load_uint32(0x3fffffff, &b);
+	bn_read_uint32(0x3fffffff, &b);
 
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 
 	// bit 31 set
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
-	bn_load_uint32(0x40000000, &b);
+	bn_read_uint32(0x40000000, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 }
 END_TEST
 
-START_TEST(test_bignum_load_uint64)
+START_TEST(test_bignum_read_uint64)
 {
 	bignum256 a;
 	bignum256 b;
 
 	// lowest 30 bits set
 	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
-	bn_load_uint64(0x3fffffff, &b);
+	bn_read_uint64(0x3fffffff, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 
 	// bit 31 set
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
-	bn_load_uint64(0x40000000, &b);
+	bn_read_uint64(0x40000000, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 
 	// bit 33 set
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000100000000"), &a);
-	bn_load_uint64(0x100000000LL, &b);
+	bn_read_uint64(0x100000000LL, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 
 	// bit 61 set
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000002000000000000000"), &a);
-	bn_load_uint64(0x2000000000000000LL, &b);
+	bn_read_uint64(0x2000000000000000LL, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 
 	// all 64 bits set
 	bn_read_be(fromhex("000000000000000000000000000000000000000000000000ffffffffffffffff"), &a);
-	bn_load_uint64(0xffffffffffffffffLL, &b);
+	bn_read_uint64(0xffffffffffffffffLL, &b);
 	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
 }
 END_TEST
@@ -2527,8 +2527,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_is_zero);
 	tcase_add_test(tc, test_bignum_read_le);
 	tcase_add_test(tc, test_bignum_write_le);
-	tcase_add_test(tc, test_bignum_load_uint32);
-	tcase_add_test(tc, test_bignum_load_uint64);
+	tcase_add_test(tc, test_bignum_read_uint32);
+	tcase_add_test(tc, test_bignum_read_uint64);
 	tcase_add_test(tc, test_bignum_copy);
 	tcase_add_test(tc, test_bignum_is_even);
 	tcase_add_test(tc, test_bignum_is_odd);

--- a/tests.c
+++ b/tests.c
@@ -153,6 +153,56 @@ START_TEST(test_bignum_write_le)
 }
 END_TEST
 
+START_TEST(test_bignum_load_uint32)
+{
+	bignum256 a;
+	bignum256 b;
+
+	// lowest 30 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
+	bn_load_uint32(0x3fffffff, &b);
+
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	// bit 31 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
+	bn_load_uint32(0x40000000, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
+START_TEST(test_bignum_load_uint64)
+{
+	bignum256 a;
+	bignum256 b;
+
+	// lowest 30 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000003fffffff"), &a);
+	bn_load_uint64(0x3fffffff, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	// bit 31 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000040000000"), &a);
+	bn_load_uint64(0x40000000, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	// bit 33 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000100000000"), &a);
+	bn_load_uint64(0x100000000LL, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	// bit 61 set
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000002000000000000000"), &a);
+	bn_load_uint64(0x2000000000000000LL, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+
+	// all 64 bits set
+	bn_read_be(fromhex("000000000000000000000000000000000000000000000000ffffffffffffffff"), &a);
+	bn_load_uint64(0xffffffffffffffffLL, &b);
+	ck_assert_int_eq(bn_is_equal(&a, &b), 1);
+}
+END_TEST
+
 START_TEST(test_bignum_copy)
 {
 	bignum256 a;
@@ -2445,6 +2495,8 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_equal);
 	tcase_add_test(tc, test_bignum_read_le);
 	tcase_add_test(tc, test_bignum_write_le);
+	tcase_add_test(tc, test_bignum_load_uint32);
+	tcase_add_test(tc, test_bignum_load_uint64);
 	tcase_add_test(tc, test_bignum_copy);
 	tcase_add_test(tc, test_bignum_is_even);
 	tcase_add_test(tc, test_bignum_is_odd);


### PR DESCRIPTION
This adds
- a few basic tests (read_be, write_be, equal) to build other bignum tests from.
- little endian read/write
- copy/duplicate
