### PR TITLE
Reworked rfc6979 signing.

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -415,25 +415,25 @@ int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash)
 
 // msg is a data to be signed
 // msg_len is the message length
-int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby)
+int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]))
 {
 	if (node->curve == &ed25519_info) {
 		hdnode_fill_public_key(node);
 		ed25519_sign(msg, msg_len, node->private_key, node->public_key + 1, sig);
 		return 0;
 	} else {
-		return ecdsa_sign(node->curve->params, node->private_key, msg, msg_len, sig, pby);
+		return ecdsa_sign(node->curve->params, node->private_key, msg, msg_len, sig, pby, is_canonical);
 	}
 }
 
-int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby)
+int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]))
 {
 	if (node->curve == &ed25519_info) {
 		hdnode_fill_public_key(node);
 		ed25519_sign(digest, 32, node->private_key, node->public_key + 1, sig);
 		return 0;
 	} else {
-		return ecdsa_sign_digest(node->curve->params, node->private_key, digest, sig, pby);
+		return ecdsa_sign_digest(node->curve->params, node->private_key, digest, sig, pby, is_canonical);
 	}
 }
 

--- a/bip32.h
+++ b/bip32.h
@@ -71,8 +71,8 @@ void hdnode_fill_public_key(HDNode *node);
 int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash);
 #endif
 
-int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby);
-int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby);
+int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
+int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
 
 void hdnode_serialize_public(const HDNode *node, uint32_t fingerprint, char *str, int strsize);
 

--- a/ecdsa.h
+++ b/ecdsa.h
@@ -48,6 +48,11 @@ typedef struct {
 
 } ecdsa_curve;
 
+// rfc6979 pseudo random number generator state
+typedef struct {
+	uint8_t v[32], k[32];
+} rfc6979_state;
+
 void point_copy(const curve_point *cp1, curve_point *cp2);
 void point_add(const ecdsa_curve *curve, const curve_point *cp1, curve_point *cp2);
 void point_double(const ecdsa_curve *curve, curve_point *cp);
@@ -60,9 +65,9 @@ void scalar_multiply(const ecdsa_curve *curve, const bignum256 *k, curve_point *
 void uncompress_coords(const ecdsa_curve *curve, uint8_t odd, const bignum256 *x, bignum256 *y);
 int ecdsa_uncompress_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key, uint8_t *uncompressed);
 
-int ecdsa_sign(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby);
-int ecdsa_sign_double(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby);
-int ecdsa_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *digest, uint8_t *sig, uint8_t *pby);
+int ecdsa_sign(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
+int ecdsa_sign_double(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
+int ecdsa_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *digest, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
 void ecdsa_get_public_key33(const ecdsa_curve *curve, const uint8_t *priv_key, uint8_t *pub_key);
 void ecdsa_get_public_key65(const ecdsa_curve *curve, const uint8_t *priv_key, uint8_t *pub_key);
 void ecdsa_get_pubkeyhash(const uint8_t *pub_key, uint8_t *pubkeyhash);
@@ -80,7 +85,8 @@ int ecdsa_verify_digest_recover(const ecdsa_curve *curve, uint8_t *pub_key, cons
 int ecdsa_sig_to_der(const uint8_t *sig, uint8_t *der);
 
 // Private
-int generate_k_rfc6979(const ecdsa_curve *curve, bignum256 *secret, const uint8_t *priv_key, const uint8_t *hash);
-int generate_k_random(const ecdsa_curve *curve, bignum256 *k);
+void init_k_rfc6979(const uint8_t *priv_key, const uint8_t *hash, rfc6979_state *rng);
+void generate_k_rfc6979(bignum256 *k, rfc6979_state *rng);
+void generate_k_random(bignum256 *k);
 
 #endif

--- a/test-openssl.c
+++ b/test-openssl.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 		}
 
 		// use our ECDSA signer to sign the message with the key
-		if (ecdsa_sign(CURVE, priv_key, msg, msg_len, sig, 0) != 0) {
+		if (ecdsa_sign(CURVE, priv_key, msg, msg_len, sig, NULL, NULL) != 0) {
 			printf("trezor-crypto signing failed\n");
 			break;
 		}

--- a/test_curves.py
+++ b/test_curves.py
@@ -380,7 +380,7 @@ def test_sign(curve, r):
     digest = r.randbytes(32)
     sig = r.randbytes(64)
 
-    lib.ecdsa_sign_digest(curve.ptr, priv, digest, sig, c.c_void_p(0))
+    lib.ecdsa_sign_digest(curve.ptr, priv, digest, sig, c.c_void_p(0), c.c_void_p(0))
 
     exp = bytes2num(priv)
     sk = ecdsa.SigningKey.from_secret_exponent(exp, curve,

--- a/test_speed.c
+++ b/test_speed.c
@@ -25,7 +25,7 @@ void bench_secp256k1(void) {
 
 	memcpy(priv, "\xc5\x5e\xce\x85\x8b\x0d\xdd\x52\x63\xf9\x68\x10\xfe\x14\x43\x7c\xd3\xb5\xe1\xfb\xd7\xc6\xa2\xec\x1e\x03\x1f\x05\xe8\x6d\x8b\xd5", 32);
 	ecdsa_get_public_key33(curve, priv, pub);
-	ecdsa_sign(curve, priv, msg, sizeof(msg), sig, &pby);
+	ecdsa_sign(curve, priv, msg, sizeof(msg), sig, &pby, NULL);
 
 	clock_t t = clock();
 	for (int i = 0 ; i < 500; i++) {
@@ -42,7 +42,7 @@ void bench_nist256p1(void) {
 
 	memcpy(priv, "\xc5\x5e\xce\x85\x8b\x0d\xdd\x52\x63\xf9\x68\x10\xfe\x14\x43\x7c\xd3\xb5\xe1\xfb\xd7\xc6\xa2\xec\x1e\x03\x1f\x05\xe8\x6d\x8b\xd5", 32);
 	ecdsa_get_public_key33(curve, priv, pub);
-	ecdsa_sign(curve, priv, msg, sizeof(msg), sig, &pby);
+	ecdsa_sign(curve, priv, msg, sizeof(msg), sig, &pby, NULL);
 
 	clock_t t = clock();
 	for (int i = 0 ; i < 500; i++) {

--- a/tests.c
+++ b/tests.c
@@ -1266,18 +1266,17 @@ END_TEST
 
 #define test_deterministic(KEY, MSG, K) do {	  \
 	sha256_Raw((uint8_t *)MSG, strlen(MSG), buf); \
-	res = generate_k_rfc6979(curve, &k, fromhex(KEY), buf); \
-	ck_assert_int_eq(res, 0); \
+	init_k_rfc6979(fromhex(KEY), buf, &rng); \
+	generate_k_rfc6979(&k, &rng); \
 	bn_write_be(&k, buf); \
 	ck_assert_mem_eq(buf, fromhex(K), 32); \
 } while (0)
 
 START_TEST(test_rfc6979)
 {
-	int res;
 	bignum256 k;
 	uint8_t buf[32];
-	const ecdsa_curve *curve = &secp256k1;
+	rfc6979_state rng;
 
 	test_deterministic("cca9fbcc1b41e5a95d369eaa6ddcff73b61a4efaa279cfc6567e8daa39cbaf50", "sample", "2df40ca70e639d89528a6b670d9d48d9165fdc0febc0974056bdce192b8e16a3");
 	test_deterministic("0000000000000000000000000000000000000000000000000000000000000001", "Satoshi Nakamoto", "8f8a276c19f4149656b280621e358cce24f5f52542772691ee69063b74f15d15");
@@ -1303,13 +1302,13 @@ START_TEST(test_sign_speed)
 
 	memcpy(priv_key, fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), 32);
 	for (i = 0 ; i < 250; i++) {
-		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, 0);
+		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, NULL, NULL);
 		ck_assert_int_eq(res, 0);
 	}
 
 	memcpy(priv_key, fromhex("509a0382ff5da48e402967a671bdcde70046d07f0df52cff12e8e3883b426a0a"), 32);
 	for (i = 0 ; i < 250; i++) {
-		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, 0);
+		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, NULL, NULL);
 		ck_assert_int_eq(res, 0);
 	}
 
@@ -1320,13 +1319,13 @@ START_TEST(test_sign_speed)
 
 	memcpy(priv_key, fromhex("c55ece858b0ddd5263f96810fe14437cd3b5e1fbd7c6a2ec1e031f05e86d8bd5"), 32);
 	for (i = 0 ; i < 250; i++) {
-		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, 0);
+		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, NULL, NULL);
 		ck_assert_int_eq(res, 0);
 	}
 
 	memcpy(priv_key, fromhex("509a0382ff5da48e402967a671bdcde70046d07f0df52cff12e8e3883b426a0a"), 32);
 	for (i = 0 ; i < 250; i++) {
-		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, 0);
+		res = ecdsa_sign(curve, priv_key, msg, sizeof(msg), sig, NULL, NULL);
 		ck_assert_int_eq(res, 0);
 	}
 


### PR DESCRIPTION
This adds an is_canonic parameter to all sign functions.  This is a
callback that determines if a signature corresponds to some coin
specific rules.  It is used, e. g., by ethereum (where the recovery
byte must be 0 or 1, and not 2 or 3) and or steem signatures (which
require both r and s to be between 2^248 and 2^255).

This also separates the initialization and the step function of the
random number generator, making it easy to restart the signature
process with the next random number.

It also fixes the (very unlikely) case where the signature is invalid
because the r or s value is zero.  Previously the signing process
failed; now it just tries the next k value.