### PR TITLE
bip32: allow Ed25519 signing larger digests

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -444,15 +444,18 @@ int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig
 	}
 }
 
-int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]))
+int hdnode_sign_digest(HDNode *node, const uint8_t *digest, int digest_size, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]))
 {
 	if (node->curve == &ed25519_info) {
 		hdnode_fill_public_key(node);
-		ed25519_sign(digest, 32, node->private_key, node->public_key + 1, sig);
+		ed25519_sign(digest, digest_size, node->private_key, node->public_key + 1, sig);
 		return 0;
 	} else if (node->curve == &curve25519_info) {
 		return 1;  // signatures are not supported
 	} else {
+		if (digest_size != 32) {
+			return 1;  // only 256-bit digests are supported for NIST256 signatures
+		}
 		return ecdsa_sign_digest(node->curve->params, node->private_key, digest, sig, pby, is_canonical);
 	}
 }

--- a/bip32.h
+++ b/bip32.h
@@ -72,7 +72,7 @@ int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash);
 #endif
 
 int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
-int hdnode_sign_digest(HDNode *node, const uint8_t *digest, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
+int hdnode_sign_digest(HDNode *node, const uint8_t *digest, int digest_size, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64]));
 
 int hdnode_get_shared_key(const HDNode *node, const uint8_t *peer_public_key, uint8_t *session_key, int *result_size);
 


### PR DESCRIPTION
P.S.
I have based this PR on not upon the latest `trezor-crypto` version, since using the latest `trezor-crypto` as a submodule in `trezor-mcu` causes the build to fail (due to missing USE_GRAPHENE directive in `trezor-mcu` Makefile) and I wasn't sure whether you'd like to add Steem support into the TREZOR firmware now.