### PR TITLE
Use bn_add instead of bn_addmod

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -178,7 +178,7 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
 			if (!bn_is_less(&b, &inout->curve->params->order)) { // >= order
 				failed = true;
 			} else {
-				bn_addmod(&b, &a, &inout->curve->params->order);
+				bn_add(&b, &a);
 				bn_mod(&b, &inout->curve->params->order);
 				if (bn_is_zero(&b)) {
 					failed = true;


### PR DESCRIPTION
The bip32 private key derivation used bn_addmod to handle
wrap around.  This was never sufficient as bn_addmod uses only
bn_fast_mod, so an additional bn_mod is necessary.  The bn_fast_mod
helped when bn_mod was not side-channel safe.  Now that bn_mod uses
constant time code, we can get rid of the unnecessary bn_fast_mod
step and use bn_add instead of bn_addmod.