### PR TITLE
Fix for subunit tests on Ubuntu > 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ SRCS  += blake2b.c blake2s.c
 
 OBJS   = $(SRCS:.c=.o)
 
-TESTLIBS = -lcheck -lrt -lpthread -lm
-TESTSSLLIBS = -lcrypto
+TESTLIBS = -lcheck -lrt -lpthread -lm -lsubunit
+TESTSSLLIBS = -lcrypto 
 
 all: tests test-openssl libtrezor-crypto.so test_speed tools
 


### PR DESCRIPTION
`tests` binary didn't get linked:
https://github.com/libcheck/check/issues/60