### PR TITLE
Constant-time verification with Valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
     - cmake-data
     - libssl-dev
     - python-pip
+    - valgrind
 
 install:
   - pip install --user pytest ecdsa curve25519-donna
@@ -21,6 +22,7 @@ install:
 script:
   - make
   - ./tests
+  - CK_TIMEOUT_MULTIPLIER=20 valgrind -q --error-exitcode=1 ./tests
   - ./test-openssl 1000
   - ITERS=10 py.test
   - mkdir _build && cd _build && cmake .. && make && cd ..

--- a/check_mem.h
+++ b/check_mem.h
@@ -1,6 +1,8 @@
 #ifndef CHECK_MEM_H
 #define CHECK_MEM_H
 
+#if CHECK_MAJOR_VERSION == 0 && CHECK_MINOR_VERSION < 11
+
 #define _ck_assert_mem(X, Y, L, OP) do { \
   const char* _ck_x = (const char*)(void*)(X); \
   const char* _ck_y = (const char*)(void*)(Y); \
@@ -22,5 +24,7 @@
 } while (0)
 #define ck_assert_mem_eq(X, Y, L) _ck_assert_mem(X, Y, L, ==)
 #define ck_assert_mem_ne(X, Y, L) _ck_assert_mem(X, Y, L, !=)
+
+#endif
 
 #endif

--- a/tests.c
+++ b/tests.c
@@ -2594,11 +2594,8 @@ static void test_codepoints_curve(const ecdsa_curve *curve) {
 	}
 }
 
-START_TEST(test_codepoints) {
-	test_codepoints_curve(&secp256k1);
-	test_codepoints_curve(&nist256p1);
-}
-END_TEST
+START_TEST(test_codepoints_secp256k1) { test_codepoints_curve(&secp256k1); } END_TEST
+START_TEST(test_codepoints_nist256p1) { test_codepoints_curve(&nist256p1); } END_TEST
 
 static void test_mult_border_cases_curve(const ecdsa_curve *curve) {
 	bignum256 a;
@@ -2645,11 +2642,8 @@ static void test_mult_border_cases_curve(const ecdsa_curve *curve) {
 	ck_assert_mem_eq(&p, &expected, sizeof(curve_point));
 }
 
-START_TEST(test_mult_border_cases) {
-	test_mult_border_cases_curve(&secp256k1);
-	test_mult_border_cases_curve(&nist256p1);
-}
-END_TEST
+START_TEST(test_mult_border_cases_secp256k1) { test_mult_border_cases_curve(&secp256k1); } END_TEST
+START_TEST(test_mult_border_cases_nist256p1) { test_mult_border_cases_curve(&nist256p1); } END_TEST
 
 static void test_scalar_mult_curve(const ecdsa_curve *curve) {
 	int i;
@@ -2674,11 +2668,8 @@ static void test_scalar_mult_curve(const ecdsa_curve *curve) {
 	}
 }
 
-START_TEST(test_scalar_mult) {
-	test_scalar_mult_curve(&secp256k1);
-	test_scalar_mult_curve(&nist256p1);
-}
-END_TEST
+START_TEST(test_scalar_mult_secp256k1) { test_scalar_mult_curve(&secp256k1); } END_TEST
+START_TEST(test_scalar_mult_nist256p1) { test_scalar_mult_curve(&nist256p1); } END_TEST
 
 static void test_point_mult_curve(const ecdsa_curve *curve) {
 	int i;
@@ -2705,11 +2696,8 @@ static void test_point_mult_curve(const ecdsa_curve *curve) {
 	}
 }
 
-START_TEST(test_point_mult) {
-	test_point_mult_curve(&secp256k1);
-	test_point_mult_curve(&nist256p1);
-}
-END_TEST
+START_TEST(test_point_mult_secp256k1) { test_point_mult_curve(&secp256k1); } END_TEST
+START_TEST(test_point_mult_nist256p1) { test_point_mult_curve(&nist256p1); } END_TEST
 
 static void test_scalar_point_mult_curve(const ecdsa_curve *curve) {
 	int i;
@@ -2743,11 +2731,8 @@ static void test_scalar_point_mult_curve(const ecdsa_curve *curve) {
 	}
 }
 
-START_TEST(test_scalar_point_mult) {
-	test_scalar_point_mult_curve(&secp256k1);
-	test_scalar_point_mult_curve(&nist256p1);
-}
-END_TEST
+START_TEST(test_scalar_point_mult_secp256k1) { test_scalar_point_mult_curve(&secp256k1); } END_TEST
+START_TEST(test_scalar_point_mult_nist256p1) { test_scalar_point_mult_curve(&nist256p1); } END_TEST
 
 START_TEST(test_ed25519) {
 	// test vectors from https://github.com/torproject/tor/blob/master/src/test/ed25519_vectors.inc
@@ -3219,24 +3204,28 @@ Suite *test_suite(void)
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("codepoints");
-	tcase_add_test(tc, test_codepoints);
-	tcase_set_timeout(tc, 8);
+	tcase_add_test(tc, test_codepoints_secp256k1);
+	tcase_add_test(tc, test_codepoints_nist256p1);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("mult_border_cases");
-	tcase_add_test(tc, test_mult_border_cases);
+	tcase_add_test(tc, test_mult_border_cases_secp256k1);
+	tcase_add_test(tc, test_mult_border_cases_nist256p1);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("scalar_mult");
-	tcase_add_test(tc, test_scalar_mult);
+	tcase_add_test(tc, test_scalar_mult_secp256k1);
+	tcase_add_test(tc, test_scalar_mult_nist256p1);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("point_mult");
-	tcase_add_test(tc, test_point_mult);
+	tcase_add_test(tc, test_point_mult_secp256k1);
+	tcase_add_test(tc, test_point_mult_nist256p1);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("scalar_point_mult");
-	tcase_add_test(tc, test_scalar_point_mult);
+	tcase_add_test(tc, test_scalar_point_mult_secp256k1);
+	tcase_add_test(tc, test_scalar_point_mult_nist256p1);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("ed25519");

--- a/tests.c
+++ b/tests.c
@@ -3157,10 +3157,12 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_rfc6979);
 	suite_add_tcase(s, tc);
 
-	tc = tcase_create("speed");
-	tcase_add_test(tc, test_sign_speed);
-	tcase_add_test(tc, test_verify_speed);
-	suite_add_tcase(s, tc);
+	if (!RUNNING_ON_VALGRIND) {
+		tc = tcase_create("speed");
+		tcase_add_test(tc, test_sign_speed);
+		tcase_add_test(tc, test_verify_speed);
+		suite_add_tcase(s, tc);
+	}
 
 	tc = tcase_create("address");
 	tcase_add_test(tc, test_address);

--- a/tests.c
+++ b/tests.c
@@ -30,6 +30,9 @@
 #include <check.h>
 #include "check_mem.h"
 
+#include <valgrind/valgrind.h>
+#include <valgrind/memcheck.h>
+
 #include "options.h"
 
 #include "aes.h"
@@ -50,6 +53,16 @@
 #include "ed25519.h"
 #include "script.h"
 #include "rfc6979.h"
+
+/*
+ * This is a clever trick to make Valgrind's Memcheck verify code
+ * is constant-time with respect to secret data.
+ */
+
+/* Call after secret data is written, before first use */
+#define   MARK_SECRET_DATA(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
+/* Call before secret data is freed */
+#define UNMARK_SECRET_DATA(addr, len) VALGRIND_MAKE_MEM_DEFINED  (addr, len)
 
 #define FROMHEX_MAXLEN 256
 


### PR DESCRIPTION
This pull request marks secret data as uninitialized, which causes Memcheck to throw an error when a pointer expression, conditional jump or conditional move depends on the secret data. This allows verification that a function is constant-time, with respect to the secret data.

* Fixed `check_mem.h` for Check 0.11
* Added `MARK_SECRET_DATA` and `UNMARK_SECRET_DATA` to inform Valgrind should be handled in constant-time
* Added Valgrind to Travis CI
* Skip speed tests when running on Valgrind
* Split curve tests into individual tests (to reduce individual test case time)
* Added `MARK_SECRET_DATA` in `test_ed25519` and `test_ed25519_cosi` to verify `ed25519-donna` is constant-time