### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These include:
 - ECDSA signing/verifying (supports secp256k1 and nist256p1 curves,
   uses RFC6979 for deterministic signatures)
 - ECDSA public key derivation
-- Base32 (RFC4648)
+- Base32 (RFC4648 and custom alphabets)
 - Base58 address representation
 - Ed25519 signing/verifying (also SHA3 and Keccak variants)
 - ECDH using secp256k1, nist256p1 and Curve25519

--- a/aes/aescrypt.c
+++ b/aes/aescrypt.c
@@ -115,10 +115,12 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
         kp += 2 * N_COLS;
+        //-fallthrough
     case 12 * 16:
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
         kp += 2 * N_COLS;
+        //-fallthrough
     case 10 * 16:
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
@@ -130,6 +132,7 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
         round(fwd_rnd,  b0, b1, kp + 8 * N_COLS);
         round(fwd_rnd,  b1, b0, kp + 9 * N_COLS);
         round(fwd_lrnd, b0, b1, kp +10 * N_COLS);
+        //-fallthrough
     }
 
 #else
@@ -247,9 +250,11 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
     case 14 * 16:
         round(inv_rnd,  b1, b0, rnd_key(-13));
         round(inv_rnd,  b0, b1, rnd_key(-12));
+        //-fallthrough
     case 12 * 16:
         round(inv_rnd,  b1, b0, rnd_key(-11));
         round(inv_rnd,  b0, b1, rnd_key(-10));
+        //-fallthrough
     case 10 * 16:
         round(inv_rnd,  b1, b0, rnd_key(-9));
         round(inv_rnd,  b0, b1, rnd_key(-8));
@@ -261,6 +266,7 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
         round(inv_rnd,  b0, b1, rnd_key(-2));
         round(inv_rnd,  b1, b0, rnd_key(-1));
         round(inv_lrnd, b0, b1, rnd_key( 0));
+        //-fallthrough
     }
 
 #else

--- a/base58.c
+++ b/base58.c
@@ -90,11 +90,14 @@ bool b58tobin(void *bin, size_t *binszp, const char *b58)
 	switch (bytesleft) {
 		case 3:
 			*(binu++) = (outi[0] &   0xff0000) >> 16;
+			//-fallthrough
 		case 2:
 			*(binu++) = (outi[0] &     0xff00) >>  8;
+			//-fallthrough
 		case 1:
 			*(binu++) = (outi[0] &       0xff);
 			++j;
+			//-fallthrough
 		default:
 			break;
 	}

--- a/test_check.c
+++ b/test_check.c
@@ -504,23 +504,25 @@ END_TEST
 START_TEST(test_base32_rfc4648)
 {
 	static const struct {
-		const char *input;
-		const char *output;
+		const char *decoded;
+		const char *encoded;
+		const char *encoded_lowercase;
 	} tests[] = {
-		{ "",       "" },
-		{ "f",      "MY" },
-		{ "fo",     "MZXQ" },
-		{ "foo",    "MZXW6" },
-		{ "foob",   "MZXW6YQ" },
-		{ "fooba",  "MZXW6YTB" },
-		{ "foobar", "MZXW6YTBOI" },
+		{ "",       "",           ""},
+		{ "f",      "MY",         "my" },
+		{ "fo",     "MZXQ",       "mzxq" },
+		{ "foo",    "MZXW6",      "mzxw6" },
+		{ "foob",   "MZXW6YQ",    "mzxw6yq" },
+		{ "fooba",  "MZXW6YTB",   "mzxw6ytb" },
+		{ "foobar", "MZXW6YTBOI", "mzxw6ytboi" },
 	};
 
 	char buffer[64];
 
 	for (size_t i = 0; i < (sizeof(tests) / sizeof(*tests)); i++) {
-		const char *in  = tests[i].input;
-		const char *out = tests[i].output;
+		const char *in  = tests[i].decoded;
+		const char *out = tests[i].encoded;
+		const char *out_lowercase = tests[i].encoded_lowercase;
 
 		size_t inlen = strlen(in);
 		size_t outlen = strlen(out);
@@ -533,7 +535,11 @@ START_TEST(test_base32_rfc4648)
 
 		char *ret = (char *) base32_decode(out, outlen, (uint8_t *) buffer, sizeof(buffer), BASE32_ALPHABET_RFC4648);
 		ck_assert(ret != NULL);
+		*ret = '\0';
+		ck_assert_str_eq(buffer, in);
 
+		ret = (char *) base32_decode(out_lowercase, outlen, (uint8_t *) buffer, sizeof(buffer), BASE32_ALPHABET_RFC4648);
+		ck_assert(ret != NULL);
 		*ret = '\0';
 		ck_assert_str_eq(buffer, in);
 	}


### PR DESCRIPTION
* Add `//-fallthrough` comments for GCC 7.1.1 `-Wimplicit-fallthrough` (the comments look better than `__attribute__((fallthrough));`
* Add lowercase tests for Base32 RFC4648 (the RFC alphabet is optimized and has special support for uppercase and lowercase)
* Mention custom alphabets for Base32 in `README.md`