### PR TITLE
Add integer formatting, exponent and trailing zero support to bn_format

### DIFF
--- a/bignum.h
+++ b/bignum.h
@@ -25,6 +25,8 @@
 #ifndef __BIGNUM_H__
 #define __BIGNUM_H__
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "options.h"
 
@@ -156,7 +158,7 @@ void bn_divmod58(bignum256 *a, uint32_t *r);
 
 void bn_divmod1000(bignum256 *a, uint32_t *r);
 
-int bn_format(const bignum256 *amnt, const char *prefix, const char *suffix, int decimals, char *out, int outlen);
+size_t bn_format(const bignum256 *amnt, const char *prefix, const char *suffix, unsigned int decimals, int exponent, bool trailing, char *out, size_t outlen);
 
 #if USE_BN_PRINT
 void bn_print(const bignum256 *a);

--- a/bignum.h
+++ b/bignum.h
@@ -160,6 +160,14 @@ void bn_divmod1000(bignum256 *a, uint32_t *r);
 
 size_t bn_format(const bignum256 *amnt, const char *prefix, const char *suffix, unsigned int decimals, int exponent, bool trailing, char *out, size_t outlen);
 
+static inline size_t bn_format_uint64(uint64_t amount, const char *prefix, const char *suffix, unsigned int decimals, int exponent, bool trailing, char *out, size_t outlen)
+{
+	bignum256 amnt;
+	bn_read_uint64(amount, &amnt);
+
+	return bn_format(&amnt, prefix, suffix, decimals, exponent, trailing, out, outlen);
+}
+
 #if USE_BN_PRINT
 void bn_print(const bignum256 *a);
 void bn_print_raw(const bignum256 *a);

--- a/bignum.h
+++ b/bignum.h
@@ -81,6 +81,17 @@ static inline void bn_copy(const bignum256 *a, bignum256 *b) {
 
 int bn_bitcount(const bignum256 *a);
 
+static inline int bn_digitcount(const bignum256 *a)
+{
+	int bitcount = bn_bitcount(a);
+
+	if (bitcount == 256) {
+		return 78;
+	} else {
+		return bitcount * 78 / 256 + 1;
+	}
+}
+
 void bn_zero(bignum256 *a);
 
 int bn_is_zero(const bignum256 *a);

--- a/test_check.c
+++ b/test_check.c
@@ -410,6 +410,21 @@ START_TEST(test_bignum_format) {
 	ck_assert_str_eq(buf, "0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
+	r = bn_format(&a, NULL, NULL, 20, 0, true, buf, sizeof(buf));
+	ck_assert_int_eq(r, 22);
+	ck_assert_str_eq(buf, "0.00000000000000000000");
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
+	r = bn_format(&a, NULL, NULL, 0, 5, false, buf, sizeof(buf));
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "0");
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
+	r = bn_format(&a, NULL, NULL, 0, -5, false, buf, sizeof(buf));
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "0");
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, "", "", 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "0");
@@ -438,6 +453,11 @@ START_TEST(test_bignum_format) {
 	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "1");
+
+	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000001"), &a);
+	r = bn_format(&a, NULL, NULL, 6, 6, true, buf, sizeof(buf));
+	ck_assert_int_eq(r, 8);
+	ck_assert_str_eq(buf, "1.000000");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000002"), &a);
 	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
@@ -523,6 +543,16 @@ START_TEST(test_bignum_format) {
 	r = bn_format(&a, NULL, NULL, 18, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 62);
 	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457.0");
+
+	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
+	r = bn_format(&a, NULL, NULL, 78, 0, false, buf, sizeof(buf));
+	ck_assert_int_eq(r, 80);
+	ck_assert_str_eq(buf, "0.115792089237316195423570985008687907853269984665640564039457584007913129639935");
+
+	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
+	r = bn_format(&a, NULL, NULL, 0, 10, false, buf, sizeof(buf));
+	ck_assert_int_eq(r, 88);
+	ck_assert_str_eq(buf, "1157920892373161954235709850086879078532699846656405640394575840079131296399350000000000");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
 	r = bn_format(&a, "quite a long prefix", "even longer suffix", 60, 0, false, buf, sizeof(buf));

--- a/test_check.c
+++ b/test_check.c
@@ -406,28 +406,28 @@ START_TEST(test_bignum_format) {
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3);
-	ck_assert_str_eq(buf, "0.0");
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, "", "", 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3);
-	ck_assert_str_eq(buf, "0.0");
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, NULL, "SFFX", 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3 + 4);
-	ck_assert_str_eq(buf, "0.0SFFX");
+	ck_assert_int_eq(r, 1 + 4);
+	ck_assert_str_eq(buf, "0SFFX");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, "PRFX", NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 4 + 3);
-	ck_assert_str_eq(buf, "PRFX0.0");
+	ck_assert_int_eq(r, 4 + 1);
+	ck_assert_str_eq(buf, "PRFX0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, "PRFX", "SFFX", 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 4 + 3 + 4);
-	ck_assert_str_eq(buf, "PRFX0.0SFFX");
+	ck_assert_int_eq(r, 4 + 1 + 4);
+	ck_assert_str_eq(buf, "PRFX0SFFX");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
 	r = bn_format(&a, NULL, NULL, 18, buf, sizeof(buf));
@@ -436,53 +436,53 @@ START_TEST(test_bignum_format) {
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000001"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3);
-	ck_assert_str_eq(buf, "1.0");
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "1");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000002"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3);
-	ck_assert_str_eq(buf, "2.0");
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "2");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000005"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 3);
-	ck_assert_str_eq(buf, "5.0");
+	ck_assert_int_eq(r, 1);
+	ck_assert_str_eq(buf, "5");
 
 	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000000000000a"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 4);
-	ck_assert_str_eq(buf, "10.0");
+	ck_assert_int_eq(r, 2);
+	ck_assert_str_eq(buf, "10");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000014"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 4);
-	ck_assert_str_eq(buf, "20.0");
+	ck_assert_int_eq(r, 2);
+	ck_assert_str_eq(buf, "20");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000032"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 4);
-	ck_assert_str_eq(buf, "50.0");
+	ck_assert_int_eq(r, 2);
+	ck_assert_str_eq(buf, "50");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000064"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 5);
-	ck_assert_str_eq(buf, "100.0");
+	ck_assert_int_eq(r, 3);
+	ck_assert_str_eq(buf, "100");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000000c8"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 5);
-	ck_assert_str_eq(buf, "200.0");
+	ck_assert_int_eq(r, 3);
+	ck_assert_str_eq(buf, "200");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000001f4"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 5);
-	ck_assert_str_eq(buf, "500.0");
+	ck_assert_int_eq(r, 3);
+	ck_assert_str_eq(buf, "500");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000003e8"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 6);
-	ck_assert_str_eq(buf, "1000.0");
+	ck_assert_int_eq(r, 4);
+	ck_assert_str_eq(buf, "1000");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000989680"), &a);
 	r = bn_format(&a, NULL, NULL, 7, buf, sizeof(buf));
@@ -491,8 +491,8 @@ START_TEST(test_bignum_format) {
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
 	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
-	ck_assert_int_eq(r, 80);
-	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457584007913129639935.0");
+	ck_assert_int_eq(r, 78);
+	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457584007913129639935");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
 	r = bn_format(&a, NULL, NULL, 1, buf, sizeof(buf));

--- a/test_check.c
+++ b/test_check.c
@@ -405,127 +405,127 @@ START_TEST(test_bignum_format) {
 	int r;
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, "", "", 0, buf, sizeof(buf));
+	r = bn_format(&a, "", "", 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, NULL, "SFFX", 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, "SFFX", 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1 + 4);
 	ck_assert_str_eq(buf, "0SFFX");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, "PRFX", NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, "PRFX", NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 4 + 1);
 	ck_assert_str_eq(buf, "PRFX0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, "PRFX", "SFFX", 0, buf, sizeof(buf));
+	r = bn_format(&a, "PRFX", "SFFX", 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 4 + 1 + 4);
 	ck_assert_str_eq(buf, "PRFX0SFFX");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000000"), &a);
-	r = bn_format(&a, NULL, NULL, 18, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 18, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 3);
 	ck_assert_str_eq(buf, "0.0");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000001"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "1");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000002"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "2");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000005"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 1);
 	ck_assert_str_eq(buf, "5");
 
 	bn_read_be(fromhex("000000000000000000000000000000000000000000000000000000000000000a"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 2);
 	ck_assert_str_eq(buf, "10");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000014"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 2);
 	ck_assert_str_eq(buf, "20");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000032"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 2);
 	ck_assert_str_eq(buf, "50");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000000064"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 3);
 	ck_assert_str_eq(buf, "100");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000000c8"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 3);
 	ck_assert_str_eq(buf, "200");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000001f4"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 3);
 	ck_assert_str_eq(buf, "500");
 
 	bn_read_be(fromhex("00000000000000000000000000000000000000000000000000000000000003e8"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 4);
 	ck_assert_str_eq(buf, "1000");
 
 	bn_read_be(fromhex("0000000000000000000000000000000000000000000000000000000000989680"), &a);
-	r = bn_format(&a, NULL, NULL, 7, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 7, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 3);
 	ck_assert_str_eq(buf, "1.0");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, NULL, NULL, 0, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 78);
 	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457584007913129639935");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, NULL, NULL, 1, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 1, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 79);
 	ck_assert_str_eq(buf, "11579208923731619542357098500868790785326998466564056403945758400791312963993.5");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, NULL, NULL, 2, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 2, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 79);
 	ck_assert_str_eq(buf, "1157920892373161954235709850086879078532699846656405640394575840079131296399.35");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, NULL, NULL, 8, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 8, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 79);
 	ck_assert_str_eq(buf, "1157920892373161954235709850086879078532699846656405640394575840079131.29639935");
 
 	bn_read_be(fromhex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffe3bbb00"), &a);
-	r = bn_format(&a, NULL, NULL, 8, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 8, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 72);
 	ck_assert_str_eq(buf, "1157920892373161954235709850086879078532699846656405640394575840079131.0");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, NULL, NULL, 18, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 18, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 79);
 	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457.584007913129639935");
 
 	bn_read_be(fromhex("fffffffffffffffffffffffffffffffffffffffffffffffff7e52fe5afe40000"), &a);
-	r = bn_format(&a, NULL, NULL, 18, buf, sizeof(buf));
+	r = bn_format(&a, NULL, NULL, 18, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 62);
 	ck_assert_str_eq(buf, "115792089237316195423570985008687907853269984665640564039457.0");
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	r = bn_format(&a, "quite a long prefix", "even longer suffix", 60, buf, sizeof(buf));
+	r = bn_format(&a, "quite a long prefix", "even longer suffix", 60, 0, false, buf, sizeof(buf));
 	ck_assert_int_eq(r, 116);
 	ck_assert_str_eq(buf, "quite a long prefix115792089237316195.423570985008687907853269984665640564039457584007913129639935even longer suffix");
 }

--- a/test_check.c
+++ b/test_check.c
@@ -350,6 +350,36 @@ START_TEST(test_bignum_bitcount)
 }
 END_TEST
 
+START_TEST(test_bignum_digitcount)
+{
+	bignum256 a;
+
+	bn_zero(&a);
+	ck_assert_int_eq(bn_digitcount(&a), 1);
+
+	bn_one(&a);
+	ck_assert_int_eq(bn_digitcount(&a), 1);
+
+	bn_read_uint32(10, &a);
+	ck_assert_int_eq(bn_digitcount(&a), 2);
+
+	bn_read_uint32(11, &a);
+	ck_assert_int_eq(bn_digitcount(&a), 2);
+
+	bn_read_uint32(100, &a);
+	ck_assert_int_eq(bn_digitcount(&a), 3);
+
+	bn_read_uint32(0x3fffffff, &a);
+	ck_assert_int_eq(bn_digitcount(&a), 10);
+
+	bn_read_uint32(0xffffffff, &a);
+	ck_assert_int_eq(bn_digitcount(&a), 10);
+
+	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
+	ck_assert_int_eq(bn_digitcount(&a), 78);
+}
+END_TEST
+
 START_TEST(test_bignum_is_less)
 {
 	bignum256 a;
@@ -3193,6 +3223,7 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_bignum_is_even);
 	tcase_add_test(tc, test_bignum_is_odd);
 	tcase_add_test(tc, test_bignum_bitcount);
+	tcase_add_test(tc, test_bignum_digitcount);
 	tcase_add_test(tc, test_bignum_is_less);
 	tcase_add_test(tc, test_bignum_format);
 	suite_add_tcase(s, tc);


### PR DESCRIPTION
When `exponent == 0` and `trailing == false`, the only change from the old `bn_format` is that when `decimals == 0`, it does not include a decimal point or trailing zero.

Also, no intermediate buffer is used. The formatted string is written directly to the output buffer, starting from the right, then `memmove` is used to move it to the left.

Fixes #102