### PR TITLE
Fix bn_digitcount

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -195,6 +195,31 @@ int bn_bitcount(const bignum256 *a)
 	return 0;
 }
 
+#define DIGITS 78 // log10(2 ^ 256)
+
+unsigned int bn_digitcount(const bignum256 *a)
+{
+	bignum256 val;
+	memcpy(&val, a, sizeof(bignum256));
+
+	unsigned int digits = 1;
+
+	for (unsigned int i = 0; i < DIGITS; i += 3) {
+		uint32_t limb;
+		bn_divmod1000(&val, &limb);
+
+		if (limb >= 100) {
+			digits = i + 3;
+		} else if (limb >= 10) {
+			digits = i + 2;
+		} else if (limb >= 1) {
+			digits = i + 1;
+		}
+	}
+
+	return digits;
+}
+
 // sets a bignum to zero.
 void bn_zero(bignum256 *a)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -999,7 +999,7 @@ size_t bn_format(const bignum256 *amnt, const char *prefix, const char *suffix, 
 		BN_FORMAT_PUSH(0);
 	}
 
-	unsigned int digits = bn_maxdigitcount(&val);
+	unsigned int digits = bn_digitcount(&val);
 	for (unsigned int i = 0; i < digits / 3; i++) {
 		uint32_t limb;
 		bn_divmod1000(&val, &limb);

--- a/bignum.h
+++ b/bignum.h
@@ -83,16 +83,7 @@ static inline void bn_copy(const bignum256 *a, bignum256 *b) {
 
 int bn_bitcount(const bignum256 *a);
 
-static inline int bn_digitcount(const bignum256 *a)
-{
-	int bitcount = bn_bitcount(a);
-
-	if (bitcount == 256) {
-		return 78;
-	} else {
-		return bitcount * 78 / 256 + 1;
-	}
-}
+unsigned int bn_digitcount(const bignum256 *a);
 
 void bn_zero(bignum256 *a);
 

--- a/bignum.h
+++ b/bignum.h
@@ -83,7 +83,7 @@ static inline void bn_copy(const bignum256 *a, bignum256 *b) {
 
 int bn_bitcount(const bignum256 *a);
 
-static inline int bn_maxdigitcount(const bignum256 *a)
+static inline int bn_digitcount(const bignum256 *a)
 {
 	int bitcount = bn_bitcount(a);
 

--- a/test_check.c
+++ b/test_check.c
@@ -391,7 +391,7 @@ START_TEST(test_bignum_digitcount)
 	bignum256 a;
 
 	bn_zero(&a);
-	ck_assert_int_eq(bn_maxdigitcount(&a), 1);
+	ck_assert_int_eq(bn_digitcount(&a), 1);
 
 	// test for 10000 and 99999 when i=5
 	for (int i = 1; i <= 19; i++) {
@@ -402,19 +402,19 @@ START_TEST(test_bignum_digitcount)
 			n = n * 10 + 9;
 		}
 		bn_read_uint64(m, &a);
-		ck_assert_int_eq(bn_maxdigitcount(&a), i);
+		ck_assert_int_eq(bn_digitcount(&a), i);
 		bn_read_uint64(n, &a);
-		ck_assert_int_eq(bn_maxdigitcount(&a), i + 1);
+		ck_assert_int_eq(bn_digitcount(&a), i);
 	}
 
 	bn_read_uint32(0x3fffffff, &a);
-	ck_assert_int_eq(bn_maxdigitcount(&a), 10);
+	ck_assert_int_eq(bn_digitcount(&a), 10);
 
 	bn_read_uint32(0xffffffff, &a);
-	ck_assert_int_eq(bn_maxdigitcount(&a), 10);
+	ck_assert_int_eq(bn_digitcount(&a), 10);
 
 	bn_read_be(fromhex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), &a);
-	ck_assert_int_eq(bn_maxdigitcount(&a), 78);
+	ck_assert_int_eq(bn_digitcount(&a), 78);
 }
 END_TEST
 

--- a/test_check.c
+++ b/test_check.c
@@ -393,18 +393,15 @@ START_TEST(test_bignum_digitcount)
 	bn_zero(&a);
 	ck_assert_int_eq(bn_digitcount(&a), 1);
 
-	// test for 10000 and 99999 when i=5
-	for (int i = 1; i <= 19; i++) {
-		uint64_t m = 1;
-		uint64_t n = 9;
-		for (int j = 2; j <= i; j++) {
-			m = m * 10;
-			n = n * 10 + 9;
-		}
+	// test for (10^i) and (10^i) - 1
+	uint64_t m = 1;
+	for (int i = 0; i <= 19; i++, m *= 10) {
 		bn_read_uint64(m, &a);
-		ck_assert_int_eq(bn_digitcount(&a), i);
+		ck_assert_int_eq(bn_digitcount(&a), i + 1);
+
+		uint64_t n = m - 1;
 		bn_read_uint64(n, &a);
-		ck_assert_int_eq(bn_digitcount(&a), i);
+		ck_assert_int_eq(bn_digitcount(&a), n == 0 ? 1 : i);
 	}
 
 	bn_read_uint32(0x3fffffff, &a);
@@ -421,18 +418,15 @@ END_TEST
 START_TEST(test_bignum_format_uint64) {
 	char buf[128], str[128];
 	int r;
-	// test for 10000 and 99999 when i=5
-	for (int i = 1; i <= 19; i++) {
-		uint64_t m = 1;
-		uint64_t n = 9;
-		for (int j = 2; j <= i; j++) {
-			m = m * 10;
-			n = n * 10 + 9;
-		}
+	// test for (10^i) and (10^i) - 1
+	uint64_t m = 1;
+	for (int i = 0; i <= 19; i++, m *= 10) {
 		sprintf(str, "%" PRIu64, m);
 		r = bn_format_uint64(m, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 		ck_assert_int_eq(r, strlen(str));
 		ck_assert_str_eq(buf, str);
+
+		uint64_t n = m - 1;
 		sprintf(str, "%" PRIu64, n);
 		r = bn_format_uint64(n, NULL, NULL, 0, 0, false, buf, sizeof(buf));
 		ck_assert_int_eq(r, strlen(str));


### PR DESCRIPTION
`bn_digitcount` used to use `bn_bitcount`. This would give the maximum digits, which would often be higher than the actual number. This would result in leading zeroes in `bn_format`.