### PR TITLE
Fix sequence point warning in AES implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ add_library(TrezorCrypto STATIC ${SOURCES})
 target_include_directories(TrezorCrypto PUBLIC .)
 target_include_directories(TrezorCrypto PUBLIC ed25519-donna)
 
-# disable sequence point warnings where they are expected
-set_source_files_properties(aeskey.c PROPERTIES
-                            COMPILE_FLAGS -Wno-sequence-point)
-
 target_compile_options(TrezorCrypto PRIVATE "-std=c99")
 
 if(MSVC)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ CFLAGS   += $(OPTFLAGS) \
             -Werror
 
 # disable sequence point warning because of AES code
-CFLAGS += -Wno-sequence-point
 CFLAGS += -I.
 CFLAGS += -Iaes
 CFLAGS += -Ichacha20poly1305

--- a/aes/aeskey.c
+++ b/aes/aeskey.c
@@ -393,8 +393,11 @@ AES_RETURN aes_xi(decrypt_key192)(const unsigned char *key, aes_decrypt_ctx cx[1
     cx->ks[v(48,(3))] = ss[3] = word_in(key, 3);
 
 #ifdef DEC_KS_UNROLL
-    cx->ks[v(48,(4))] = ff(ss[4] = word_in(key, 4));
-    cx->ks[v(48,(5))] = ff(ss[5] = word_in(key, 5));
+    ss[4] = word_in(key, 4);
+    ss[5] = word_in(key, 5);
+
+    cx->ks[v(48,(4))] = ff(ss[4]);
+    cx->ks[v(48,(5))] = ff(ss[5]);
     kdf6(cx->ks, 0); kd6(cx->ks, 1);
     kd6(cx->ks, 2);  kd6(cx->ks, 3);
     kd6(cx->ks, 4);  kd6(cx->ks, 5);
@@ -485,10 +488,15 @@ AES_RETURN aes_xi(decrypt_key256)(const unsigned char *key, aes_decrypt_ctx cx[1
     cx->ks[v(56,(3))] = ss[3] = word_in(key, 3);
 
 #ifdef DEC_KS_UNROLL
-    cx->ks[v(56,(4))] = ff(ss[4] = word_in(key, 4));
-    cx->ks[v(56,(5))] = ff(ss[5] = word_in(key, 5));
-    cx->ks[v(56,(6))] = ff(ss[6] = word_in(key, 6));
-    cx->ks[v(56,(7))] = ff(ss[7] = word_in(key, 7));
+    ss[4] = word_in(key, 4);
+    ss[5] = word_in(key, 5);
+    ss[6] = word_in(key, 6);
+    ss[7] = word_in(key, 7);
+
+    cx->ks[v(56,(4))] = ff(ss[4]);
+    cx->ks[v(56,(5))] = ff(ss[5]);
+    cx->ks[v(56,(6))] = ff(ss[6]);
+    cx->ks[v(56,(7))] = ff(ss[7]);
     kdf8(cx->ks, 0); kd8(cx->ks, 1);
     kd8(cx->ks, 2);  kd8(cx->ks, 3);
     kd8(cx->ks, 4);  kd8(cx->ks, 5);

--- a/aes/aestst.c
+++ b/aes/aestst.c
@@ -1,0 +1,180 @@
+/*
+ ---------------------------------------------------------------------------
+ Copyright (c) 1998-2008, Brian Gladman, Worcester, UK. All rights reserved.
+
+ LICENSE TERMS
+
+ The redistribution and use of this software (with or without changes)
+ is allowed without the payment of fees or royalties provided that:
+
+  1. source code distributions include the above copyright notice, this
+     list of conditions and the following disclaimer;
+
+  2. binary distributions include the above copyright notice, this list
+     of conditions and the following disclaimer in their documentation;
+
+  3. the name of the copyright holder is not used to endorse products
+     built using this software without specific written permission.
+
+ DISCLAIMER
+
+ This software is provided 'as is' with no explicit or implied warranties
+ in respect of its properties, including, but not limited to, correctness
+ and/or fitness for purpose.
+ ---------------------------------------------------------------------------
+ Issue Date: 20/12/2007
+*/
+
+// Correct Output (for variable block size - AES_BLOCK_SIZE undefined):
+
+// lengths:  block = 16 bytes, key = 16 bytes
+// key     = 2b7e151628aed2a6abf7158809cf4f3c
+// input   = 3243f6a8885a308d313198a2e0370734
+// encrypt = 3925841d02dc09fbdc118597196a0b32
+// decrypt = 3243f6a8885a308d313198a2e0370734
+
+// lengths:  block = 16 bytes, key = 24 bytes
+// key     = 2b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da5
+// input   = 3243f6a8885a308d313198a2e0370734
+// encrypt = f9fb29aefc384a250340d833b87ebc00
+// decrypt = 3243f6a8885a308d313198a2e0370734
+
+// lengths:  block = 16 bytes, key = 32 bytes
+// key     = 2b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfe
+// input   = 3243f6a8885a308d313198a2e0370734
+// encrypt = 1a6e6c2c662e7da6501ffb62bc9e93f3
+// decrypt = 3243f6a8885a308d313198a2e0370734
+
+#include <stdio.h>
+#include <string.h>
+
+#include "aes.h"
+#include "aestst.h"
+
+void out_state(long s0, long s1, long s2, long s3)
+{
+    printf("\n%08x%08x508x%08x", s0, s1, s2, s3);
+}
+
+void oblk(char m[], unsigned char v[], unsigned long n)
+{   unsigned long i;
+    
+    printf("\n%s", m);
+
+    for(i = 0; i < n; ++i)
+        printf("%02x", v[i]);
+}
+
+void message(const char *s)   { printf(s); }
+
+unsigned char pih[32] = // hex digits of pi
+{
+    0x32, 0x43, 0xf6, 0xa8, 0x88, 0x5a, 0x30, 0x8d,
+    0x31, 0x31, 0x98, 0xa2, 0xe0, 0x37, 0x07, 0x34,
+    0x4a, 0x40, 0x93, 0x82, 0x22, 0x99, 0xf3, 0x1d,
+    0x00, 0x82, 0xef, 0xa9, 0x8e, 0xc4, 0xe6, 0xc8
+};
+
+unsigned char exh[32] =  // hex digits of e
+{
+    0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+    0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
+    0x76, 0x2e, 0x71, 0x60, 0xf3, 0x8b, 0x4d, 0xa5,
+    0x6a, 0x78, 0x4d, 0x90, 0x45, 0x19, 0x0c, 0xfe
+};
+
+unsigned char res[3][32] =
+{
+    { 0x39, 0x25, 0x84, 0x1d, 0x02, 0xdc, 0x09, 0xfb,
+        0xdc, 0x11, 0x85, 0x97, 0x19, 0x6a, 0x0b, 0x32
+    },
+    { 0xf9, 0xfb, 0x29, 0xae, 0xfc, 0x38, 0x4a, 0x25,
+        0x03, 0x40, 0xd8, 0x33, 0xb8, 0x7e, 0xbc, 0x00
+    },
+    { 0x1a, 0x6e, 0x6c, 0x2c, 0x66, 0x2e, 0x7d, 0xa6,
+        0x50, 0x1f, 0xfb, 0x62, 0xbc, 0x9e, 0x93, 0xf3
+    }
+};
+
+void cycles(volatile uint64_t *rtn)
+{
+#if defined( _MSCVER )
+    __asm   // read the Pentium Time Stamp Counter
+    {   cpuid
+        rdtsc
+        mov     ecx,rtn
+        mov     [ecx],eax
+        mov     [ecx+4],edx
+        cpuid
+    }
+#elif defined( __GNUC__ )
+    __asm__ __volatile__("rdtsc": "=A" (*rtn));
+#endif
+}
+
+int main(void)
+{   unsigned char   out[32], ret[32], err = 0;
+    f_ectx          alge[1];
+    f_dctx          algd[1];
+
+#if defined(STATIC_TABLES)
+    aes_init();
+#endif
+
+    message("\nRun tests for the AES algorithm");
+
+    memset(&alge, 0, sizeof(aes_encrypt_ctx));
+    memset(&algd, 0, sizeof(aes_decrypt_ctx));
+
+#if defined( AES_128 )
+    memset(out, 0xcc, 16); memset(ret, 0xcc, 16);
+    printf("\n\n// lengths:  block = 16, bytes, key = 16 bytes");
+    f_enc_key128(alge, exh);
+    oblk("// key     = ", exh, 16);
+    oblk("// input   = ", pih, 16);
+    do_enc(alge, pih, out, 1);
+    oblk("// encrypt = ", out, 16);
+    if(memcmp(out, res[0], 16)) { message (" error"); err += 1; }
+    f_dec_key128(algd, exh);
+    do_dec(algd, out, ret, 1);
+    oblk("// decrypt = ", ret, 16);
+    if(memcmp(ret, pih, 16)) { message (" error"); err += 2; }
+#endif
+
+#if defined( AES_192 )
+    memset(out, 0xcc, 16); memset(ret, 0xcc, 16);
+    printf("\n\n// lengths:  block = 16, bytes, key = 24 bytes");
+    f_enc_key192(alge, exh);
+    oblk("// key     = ", exh, 24);
+    oblk("// input   = ", pih, 16);
+    do_enc(alge, pih, out, 1);
+    oblk("// encrypt = ", out, 16);
+    if(memcmp(out, res[1], 16))  { message (" error"); err += 4; }
+    f_dec_key192(algd, exh);
+    do_dec(algd, out, ret, 1);
+    oblk("// decrypt = ", ret, 16);
+    if(memcmp(ret, pih, 16))  { message (" error"); err += 8; }
+#endif
+
+#if defined( AES_256 )
+    memset(out, 0xcc, 16); memset(ret, 0xcc, 16);
+    printf("\n\n// lengths:  block = 16, bytes, key = 32 bytes");
+    f_enc_key256(alge, exh);
+    oblk("// key     = ", exh, 32);
+    oblk("// input   = ", pih, 16);
+    do_enc(alge, pih, out, 1);
+    oblk("// encrypt = ", out, 16);
+    if(memcmp(out, res[2], 16))  { message (" error"); err += 16; }
+    f_dec_key256(algd, exh);
+    do_dec(algd, out, ret, 1);
+    oblk("// decrypt = ", ret, 16);
+    if(memcmp(ret, pih, 16))  { message (" error"); err += 32; }
+#endif
+
+    if(!err)
+        message("\n\nThese values are all correct\n\n");
+    else
+        message("\n\nSome values are in error\n\n");
+
+    return 0;
+}

--- a/aes/aestst.h
+++ b/aes/aestst.h
@@ -1,0 +1,85 @@
+/*
+---------------------------------------------------------------------------
+Copyright (c) 1998-2013, Brian Gladman, Worcester, UK. All rights reserved.
+
+The redistribution and use of this software (with or without changes)
+is allowed without the payment of fees or royalties provided that:
+
+  source code distributions include the above copyright notice, this
+  list of conditions and the following disclaimer;
+
+  binary distributions include the above copyright notice, this list
+  of conditions and the following disclaimer in their documentation.
+
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its operation, including, but not limited to, correctness
+and fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 20/12/2007
+*/
+
+// The following definitions are required for testing only, They are not needed
+// for AES (Rijndael) implementation.  They are used to allow C, C++ and DLL
+// data access and subroutine calls to be expressed in the same form in the
+// testing code.
+
+#ifndef AESTST_H
+#define AESTST_H
+
+#define f_info(x)               (x)->inf.b[2]
+#define f_ectx                  aes_encrypt_ctx
+#define f_enc_key128(a,b)       aes_encrypt_key128((b),(a))
+#define f_enc_key192(a,b)       aes_encrypt_key192((b),(a))
+#define f_enc_key256(a,b)       aes_encrypt_key256((b),(a))
+#define f_enc_key(a,b,c)        aes_encrypt_key((b),(c),(a))
+#define f_enc_blk(a,b,c)        aes_encrypt((b),(c),(a))
+
+#define f_dctx                  aes_decrypt_ctx
+#define f_dec_key128(a,b)       aes_decrypt_key128((b),(a))
+#define f_dec_key192(a,b)       aes_decrypt_key192((b),(a))
+#define f_dec_key256(a,b)       aes_decrypt_key256((b),(a))
+#define f_dec_key(a,b,c)        aes_decrypt_key((b),(c),(a))
+#define f_dec_blk(a,b,c)        aes_decrypt((b),(c),(a))
+
+#define f_talign(a,b)			aes_test_alignment_detection(b)
+#define f_mode_reset(a)         aes_mode_reset(a)
+#define f_ecb_enc(a,b,c,d)      aes_ecb_encrypt((b),(c),(d),(a))
+#define f_ecb_dec(a,b,c,d)      aes_ecb_decrypt((b),(c),(d),(a))
+#define f_cbc_enc(a,b,c,d,e)    aes_cbc_encrypt((b),(c),(d),(e),(a))
+#define f_cbc_dec(a,b,c,d,e)    aes_cbc_decrypt((b),(c),(d),(e),(a))
+#define f_cfb_enc(a,b,c,d,e)    aes_cfb_encrypt((b),(c),(d),(e),(a))
+#define f_cfb_dec(a,b,c,d,e)    aes_cfb_decrypt((b),(c),(d),(e),(a))
+#define f_ofb_cry(a,b,c,d,e)    aes_ofb_crypt((b),(c),(d),(e),(a))
+#define f_ctr_cry(a,b,c,d,e,f)  aes_ctr_crypt((b),(c),(d),(e),(f),(a))
+
+#define ek_name128          "aes_encrypt_key128"
+#define ek_name192          "aes_encrypt_key192"
+#define ek_name256          "aes_encrypt_key256"
+#define ek_name             "aes_encrypt_key"
+#define eb_name             "aes_encrypt"
+
+#define dk_name128          "aes_decrypt_key128"
+#define dk_name192          "aes_decrypt_key192"
+#define dk_name256          "aes_decrypt_key256"
+#define dk_name             "aes_decrypt_key"
+#define db_name             "aes_decrypt"
+
+#define eres_name           "aes_mode_reset"
+#define ecbe_name           "aes_ecb_encrypt"
+#define ecbd_name           "aes_ecb_decrypt"
+#define cbce_name           "aes_cbc_encrypt"
+#define cbcd_name           "aes_cbc_decrypt"
+#define cfbe_name           "aes_cfb_encrypt"
+#define cfbd_name           "aes_cfb_decrypt"
+#define ofb_name            "aes_ofb_crypt"
+#define ctr_name            "aes_ctr_crypt"
+
+#ifndef AES_N_BLOCK
+#define do_enc(a,b,c,d) f_enc_blk(a, b, c)
+#define do_dec(a,b,c,d) f_dec_blk(a, b, c)
+#else
+#define do_enc(a,b,c,d) f_ecb_enc(a, b, c, AES_BLOCK_SIZE)
+#define do_dec(a,b,c,d) f_ecb_dec(a, b, c, AES_BLOCK_SIZE)
+#endif
+
+#endif


### PR DESCRIPTION
From what I can tell, neither `v`, nor `ff` access `ss`, so this should be a suitable solution to the sequence point warnings.