### PR TITLE
Added cashaddr support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ SRCS  += blake2b.c blake2s.c
 SRCS  += chacha20poly1305/chacha20poly1305.c chacha20poly1305/chacha_merged.c chacha20poly1305/poly1305-donna.c chacha20poly1305/rfc7539.c
 SRCS  += rc4.c
 SRCS  += nem.c
-SRCS  += segwit_addr.c
+SRCS  += segwit_addr.c cash_addr.c
 
 OBJS   = $(SRCS:.c=.o)
 
@@ -63,6 +63,8 @@ all: test_check test_openssl test_speed aes/aestst tools libtrezor-crypto.so
 
 %.o: %.c %.h options.h
 	$(CC) $(CFLAGS) -o $@ -c $<
+
+test_check.o: test_segwit.c test_cashaddr.c
 
 aes/aestst: aes/aestst.o aes/aescrypt.o aes/aeskey.o aes/aestab.o
 	$(CC) $^ -o $@

--- a/cash_addr.c
+++ b/cash_addr.c
@@ -1,0 +1,187 @@
+/* Copyright (c) 2017 Jochen Hoenicke
+ * based on code Copyright (c) 2017 Peter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cash_addr.h"
+
+#define MAX_CASHADDR_SIZE 129
+#define MAX_BASE32_SIZE 104
+#define MAX_DATA_SIZE 65
+#define MAX_HRP_SIZE 20
+#define CHECKSUM_SIZE 8
+
+uint64_t cashaddr_polymod_step(uint64_t pre) {
+    uint8_t b = pre >> 35;
+    return ((pre & 0x7FFFFFFFFULL) << 5) ^
+        (-((b >> 0) & 1) & 0x98f2bc8e61ULL) ^
+        (-((b >> 1) & 1) & 0x79b76d99e2ULL) ^
+        (-((b >> 2) & 1) & 0xf33e5fb3c4ULL) ^
+        (-((b >> 3) & 1) & 0xae2eabe2a8ULL) ^
+        (-((b >> 4) & 1) & 0x1e4f43e470ULL);
+}
+
+static const char* charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static const int8_t charset_rev[128] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+};
+
+int cash_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len) {
+    uint64_t chk = 1;
+    size_t i = 0;
+    while (hrp[i] != 0) {
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+		*(output++) = ch;
+        chk = cashaddr_polymod_step(chk) ^ (ch & 0x1f);
+        ++i;
+    }
+	if (i + 1 + data_len + CHECKSUM_SIZE > MAX_CASHADDR_SIZE) {
+		return 0;
+	}
+    chk = cashaddr_polymod_step(chk);
+    *(output++) = ':';
+    for (i = 0; i < data_len; ++i) {
+        if (*data >> 5) return 0;
+        chk = cashaddr_polymod_step(chk) ^ (*data);
+        *(output++) = charset[*(data++)];
+    }
+    for (i = 0; i < CHECKSUM_SIZE; ++i) {
+        chk = cashaddr_polymod_step(chk);
+    }
+    chk ^= 1;
+    for (i = 0; i < CHECKSUM_SIZE; ++i) {
+        *(output++) = charset[(chk >> ((CHECKSUM_SIZE - 1 - i) * 5)) & 0x1f];
+    }
+    *output = 0;
+    return 1;
+}
+
+int cash_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
+    uint64_t chk = 1;
+    size_t i;
+    size_t input_len = strlen(input);
+    size_t hrp_len;
+    int have_lower = 0, have_upper = 0;
+    if (input_len < CHECKSUM_SIZE || input_len > MAX_CASHADDR_SIZE) {
+        return 0;
+    }
+    *data_len = 0;
+    while (*data_len < input_len && input[(input_len - 1) - *data_len] != ':') {
+        ++(*data_len);
+    }
+    hrp_len = input_len - (1 + *data_len);
+    if (hrp_len < 1 || hrp_len > MAX_HRP_SIZE ||
+	    *data_len < CHECKSUM_SIZE || *data_len > CHECKSUM_SIZE + MAX_BASE32_SIZE) {
+        return 0;
+    }
+	// subtract checksum
+    *(data_len) -= CHECKSUM_SIZE;
+    for (i = 0; i < hrp_len; ++i) {
+        int ch = input[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+        if (ch >= 'a' && ch <= 'z') {
+            have_lower = 1;
+        } else if (ch >= 'A' && ch <= 'Z') {
+            have_upper = 1;
+            ch = (ch - 'A') + 'a';
+        }
+        hrp[i] = ch;
+        chk = cashaddr_polymod_step(chk) ^ (ch & 0x1f);
+    }
+    hrp[i] = 0;
+    chk = cashaddr_polymod_step(chk);
+    ++i;
+    while (i < input_len) {
+        int v = (input[i] & 0x80) ? -1 : charset_rev[(int)input[i]];
+        if (input[i] >= 'a' && input[i] <= 'z') have_lower = 1;
+        if (input[i] >= 'A' && input[i] <= 'Z') have_upper = 1;
+        if (v == -1) {
+            return 0;
+        }
+        chk = cashaddr_polymod_step(chk) ^ v;
+        if (i + 6 < input_len) {
+            data[i - (1 + hrp_len)] = v;
+        }
+        ++i;
+    }
+    if (have_lower && have_upper) {
+        return 0;
+    }
+    return chk == 1;
+}
+
+static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
+    uint32_t val = 0;
+    int bits = 0;
+    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
+    while (inlen--) {
+        val = (val << inbits) | *(in++);
+        bits += inbits;
+        while (bits >= outbits) {
+            bits -= outbits;
+            out[(*outlen)++] = (val >> bits) & maxv;
+        }
+    }
+    if (pad) {
+        if (bits) {
+            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
+        }
+    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
+        return 0;
+    }
+    return 1;
+}
+
+int cash_addr_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len) {
+    uint8_t base32[MAX_BASE32_SIZE];
+    size_t base32len = 0;
+    if (data_len < 2 || data_len > MAX_DATA_SIZE) return 0;
+    convert_bits(base32, &base32len, 5, data, data_len, 8, 1);
+    return cash_encode(output, hrp, base32, base32len);
+}
+
+int cash_addr_decode(uint8_t* witdata, size_t* witdata_len, const char* hrp, const char* addr) {
+    uint8_t data[MAX_BASE32_SIZE];
+    char hrp_actual[MAX_HRP_SIZE+1];
+    size_t data_len;
+    if (!cash_decode(hrp_actual, data, &data_len, addr)) return 0;
+    if (data_len == 0 || data_len > MAX_BASE32_SIZE) return 0;
+    if (strncmp(hrp, hrp_actual, MAX_HRP_SIZE + 1) != 0) return 0;
+    *witdata_len = 0;
+    if (!convert_bits(witdata, witdata_len, 8, data, data_len, 5, 0)) return 0;
+    if (*witdata_len < 2 || *witdata_len > MAX_DATA_SIZE) return 0;
+    return 1;
+}

--- a/cash_addr.h
+++ b/cash_addr.h
@@ -1,0 +1,96 @@
+/* Copyright (c) 2017 Jochen Hoenicke, Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _CASH_ADDR_H_
+#define _CASH_ADDR_H_ 1
+
+#include <stdint.h>
+
+/** Encode a Cashaddr address
+ *
+ *  Out: output:   Pointer to a buffer of size 105 + strlen(hrp) that will be
+ *                 updated to contain the null-terminated address.
+ *  In:  hrp:      Pointer to the null-terminated human readable part to use
+ *                 (chain/network specific).
+ *       prog:     Data bytes for the hash (between 21 and 65 bytes).
+ *       prog_len: Number of data bytes in prog.
+ *  Returns 1 if successful.
+ */
+int cash_addr_encode(
+    char *output,
+    const char *hrp,
+    const uint8_t *prog,
+    size_t prog_len
+);
+
+/** Decode a CashAddr address
+ *
+ *  Out: prog:     Pointer to a buffer of size 65 that will be updated to
+ *                 contain the witness program bytes.
+ *       prog_len: Pointer to a size_t that will be updated to contain the length
+ *                 of bytes in prog.
+ *       hrp:      Pointer to the null-terminated human readable part that is
+ *                 expected (chain/network specific).
+ *       addr:     Pointer to the null-terminated address.
+ *  Returns 1 if successful.
+ */
+int cash_addr_decode(
+    uint8_t* prog,
+    size_t* prog_len,
+    const char* hrp,
+    const char* addr
+);
+
+/** Encode a Cash string
+ *
+ *  Out: output:  Pointer to a buffer of size strlen(hrp) + data_len + 8 that
+ *                will be updated to contain the null-terminated Cash string.
+ *  In: hrp :     Pointer to the null-terminated human readable part.
+ *      data :    Pointer to an array of 5-bit values.
+ *      data_len: Length of the data array.
+ *  Returns 1 if successful.
+ */
+int cash_encode(
+    char *output,
+    const char *hrp,
+    const uint8_t *data,
+    size_t data_len
+);
+
+/** Decode a Cash string
+ *
+ *  Out: hrp:      Pointer to a buffer of size strlen(input) - 6. Will be
+ *                 updated to contain the null-terminated human readable part.
+ *       data:     Pointer to a buffer of size strlen(input) - 8 that will
+ *                 hold the encoded 5-bit data values.
+ *       data_len: Pointer to a size_t that will be updated to be the number
+ *                 of entries in data.
+ *  In: input:     Pointer to a null-terminated Cash string.
+ *  Returns 1 if succesful.
+ */
+int cash_decode(
+    char *hrp,
+    uint8_t *data,
+    size_t *data_len,
+    const char *input
+);
+
+#endif

--- a/ecdsa.h
+++ b/ecdsa.h
@@ -50,11 +50,13 @@ typedef struct {
 } ecdsa_curve;
 
 // 4 byte prefix + 40 byte data (segwit)
-#define MAX_ADDR_RAW_SIZE (4 + 40)
-// bottle neck is segwit bech32:
-// 4 human readable prefix + 1 separator + 64 data + 6 checksum + 1 NUL
-// the standard says 83 characters in hrp, but currently all coins use max 4
-#define MAX_ADDR_SIZE (4 + 1 + 64 + 6 + 1)
+// 1 byte prefix + 64 byte data (cashaddr)
+#define MAX_ADDR_RAW_SIZE 65
+// bottle neck is cashaddr
+// segwit is at most 90 characters plus NUL separator
+// cashaddr: human readable prefix + 1 separator + 104 data + 8 checksum + 1 NUL
+// we choose 130 as maximum (including NUL character)
+#define MAX_ADDR_SIZE 130
 // 4 byte prefix + 32 byte privkey + 1 byte compressed marker
 #define MAX_WIF_RAW_SIZE (4 + 32 + 1)
 // (4 + 32 + 1 + 4 [checksum]) * 8 / log2(58) plus NUL.

--- a/test_cashaddr.c
+++ b/test_cashaddr.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <check.h>
+
+#include "cash_addr.h"
+
+static const char* valid_cashchecksum[] = {
+	"prefix:x64nx6hz",
+	"p:gpf8m4h7",
+	"bitcoincash:qpzry9x8gf2tvdw0s3jn54khce6mua7lcw20ayyn",
+	"bchtest:testnetaddress4d6njnut",
+	"bchreg:555555555555555555555555555555555555555555555udxmlmrz",
+};
+
+struct valid_cashaddr_data {
+	const char* legacy;
+	const char* cashaddress;
+};
+
+static struct valid_cashaddr_data valid_cashaddr[] = {
+	{
+		"1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu",
+		"bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"
+	},
+	{
+		"1KXrWXciRDZUpQwQmuM1DbwsKDLYAYsVLR",
+		"bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy"
+	},
+	{
+		"16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb",
+		"bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r"
+	},
+	{
+		"3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC",
+		"bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq"
+	},
+	{
+		"3LDsS579y7sruadqu11beEJoTjdFiFCdX4",
+		"bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e"
+	},
+	{
+		"31nwvkZwyPdgzjBJZXfDmSWsC4ZLKpYyUw",
+		"bitcoincash:pqq3728yw0y47sqn6l2na30mcw6zm78dzq5ucqzc37"
+	}
+};
+
+START_TEST(test_cashaddr)
+{
+	size_t i;
+	for (i = 0; i < sizeof(valid_cashchecksum) / sizeof(valid_cashchecksum[0]); ++i) {
+		uint8_t data[82];
+		char rebuild[92];
+		char hrp[84];
+		size_t data_len;
+		int res = cash_decode(hrp, data, &data_len, valid_cashchecksum[i]);
+		ck_assert_int_eq(res, 1);
+		res = cash_encode(rebuild, hrp, data, data_len);
+		ck_assert_int_eq(res, 1);
+		printf("%s\n", rebuild);
+		printf("%s\n", valid_cashchecksum[i]);
+		ck_assert_int_eq(my_strncasecmp(rebuild, valid_cashchecksum[i], 92), 0);
+	}
+	for (i = 0; i < sizeof(valid_cashaddr) / sizeof(valid_cashaddr[0]); ++i) {
+		uint8_t prog[65];
+		size_t prog_len;
+		const char* hrp = "bitcoincash";
+		uint8_t rawdata[65];
+		size_t rawdata_len;
+		char rebuild[93];
+		int ret = cash_addr_decode(prog, &prog_len, hrp, valid_cashaddr[i].cashaddress);
+		ck_assert_int_eq(ret, 1);
+		ck_assert_int_eq(prog_len, 21);
+		rawdata_len = base58_decode_check(valid_cashaddr[i].legacy, HASHER_SHA2, rawdata, sizeof(rawdata));
+		ck_assert_int_eq(rawdata_len, 21);
+		ck_assert_int_eq(prog[0], rawdata[0] == 0 ? 0x00 : rawdata[0] == 5 ? 0x08 : -1);
+		ck_assert_int_eq(memcmp(rawdata + 1, prog + 1, 20), 0);
+		ret = cash_addr_encode(rebuild, hrp, prog, 21);
+		ck_assert_int_eq(ret, 1);
+		printf("%s\n", rebuild);
+		printf("%s\n", valid_cashaddr[i].cashaddress);
+		ck_assert_int_eq(my_strncasecmp(rebuild, valid_cashaddr[i].cashaddress, 92), 0);
+	}
+}
+END_TEST
+

--- a/test_check.c
+++ b/test_check.c
@@ -4387,6 +4387,7 @@ START_TEST(test_rc4_rfc6229)
 END_TEST
 
 #include "test_segwit.c"
+#include "test_cashaddr.c"
 
 // define test suite and cases
 Suite *test_suite(void)
@@ -4612,6 +4613,10 @@ Suite *test_suite(void)
 
 	tc = tcase_create("segwit");
 	tcase_add_test(tc, test_segwit);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("cashaddr");
+	tcase_add_test(tc, test_cashaddr);
 	suite_add_tcase(s, tc);
 
 	return s;


### PR DESCRIPTION
The new bitcoincash address format.

It is distinct from bech32 in several points:

- not limited to at most 90 characters
- 8 character checksum instead of 6
- separator is ':' instead of '1'
- only low 5 bit of hrp is used in checksum

we limit it to at most 129 characters plus NUL terminator