### PR TITLE
Makefile: simplify include path, move subdirs to where used in C files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ CFLAGS   += $(OPTFLAGS) \
             -Werror
 
 CFLAGS += -I.
-CFLAGS += -Iaes
-CFLAGS += -Ichacha20poly1305
-CFLAGS += -Ied25519-donna
 CFLAGS += -DUSE_ETHEREUM=1
 CFLAGS += -DUSE_GRAPHENE=1
 CFLAGS += -DUSE_NEM=1
@@ -56,7 +53,7 @@ SRCS  += segwit_addr.c
 
 OBJS   = $(SRCS:.c=.o)
 
-TESTLIBS = $(shell pkg-config --libs check) -lrt -lpthread -lm
+TESTLIBS = $(shell pkg-config --libs check) -lpthread -lm
 TESTSSLLIBS = -lcrypto
 
 all: test_check test_openssl test_speed aes/aestst tools libtrezor-crypto.so

--- a/bip32.c
+++ b/bip32.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-#include "aes.h"
+#include "aes/aes.h"
 #include "address.h"
 #include "bignum.h"
 #include "hmac.h"
@@ -39,10 +39,10 @@
 #include "curves.h"
 #include "secp256k1.h"
 #include "nist256p1.h"
-#include "ed25519.h"
-#include "ed25519-sha3.h"
+#include "ed25519-donna/ed25519.h"
+#include "ed25519-donna/ed25519-sha3.h"
 #if USE_KECCAK
-#include "ed25519-keccak.h"
+#include "ed25519-donna/ed25519-keccak.h"
 #endif
 #if USE_NEM
 #include "nem.h"

--- a/bip32.h
+++ b/bip32.h
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "ecdsa.h"
-#include "ed25519.h"
+#include "ed25519-donna/ed25519.h"
 #include "options.h"
 
 typedef struct {

--- a/nem.c
+++ b/nem.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 #include "base32.h"
-#include "ed25519-keccak.h"
+#include "ed25519-donna/ed25519-keccak.h"
 #include "macros.h"
 #include "ripemd160.h"
 #include "sha3.h"

--- a/nem.h
+++ b/nem.h
@@ -28,7 +28,7 @@
 #include <stdint.h>
 
 #include "bip32.h"
-#include "ed25519.h"
+#include "ed25519-donna/ed25519.h"
 
 #define NEM_LEVY_PERCENTILE_DIVISOR 4
 #define NEM_MAX_DIVISIBILITY        6

--- a/test_check.c
+++ b/test_check.c
@@ -36,7 +36,7 @@
 
 #include "options.h"
 
-#include "aes.h"
+#include "aes/aes.h"
 #include "bignum.h"
 #include "base32.h"
 #include "base58.h"
@@ -53,8 +53,8 @@
 #include "curves.h"
 #include "secp256k1.h"
 #include "nist256p1.h"
-#include "ed25519.h"
-#include "ed25519-keccak.h"
+#include "ed25519-donna/ed25519.h"
+#include "ed25519-donna/ed25519-keccak.h"
 #include "script.h"
 #include "rfc6979.h"
 #include "address.h"

--- a/test_speed.c
+++ b/test_speed.c
@@ -8,7 +8,7 @@
 #include "bip32.h"
 #include "secp256k1.h"
 #include "nist256p1.h"
-#include "ed25519.h"
+#include "ed25519-donna/ed25519.h"
 #include "hasher.h"
 
 static uint8_t msg[256];


### PR DESCRIPTION
The real purpose of this change is to make it easier to include the library into other projects.