### PR TITLE
Isolate platform-independant rand.c code into rand_pure.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ ifdef SMALL
 CFLAGS += -DUSE_PRECOMPUTED_CP=0
 endif
 
-SRCS   = bignum.c ecdsa.c curves.c secp256k1.c nist256p1.c rand.c hmac.c bip32.c bip39.c pbkdf2.c base58.c base32.c
+SRCS   = bignum.c ecdsa.c curves.c secp256k1.c nist256p1.c hmac.c bip32.c bip39.c pbkdf2.c base58.c base32.c
+SRCS  += rand.c rand_pure.c
 SRCS  += address.c
 SRCS  += script.c
 SRCS  += ripemd160.c

--- a/rand.c
+++ b/rand.c
@@ -62,13 +62,6 @@ uint32_t random32(void)
 #endif
 }
 
-uint32_t random_uniform(uint32_t n)
-{
-	uint32_t x, max = 0xFFFFFFFF - (0xFFFFFFFF % n);
-	while ((x = random32()) >= max);
-	return x / (max / n);
-}
-
 void random_buffer(uint8_t *buf, size_t len)
 {
 #ifdef _WIN32
@@ -85,16 +78,4 @@ void random_buffer(uint8_t *buf, size_t len)
 	(void)len_read;
 	assert(len_read == len);
 #endif
-}
-
-void random_permute(char *str, size_t len)
-{
-	int i, j;
-	char t;
-	for (i = len - 1; i >= 1; i--) {
-		j = random_uniform(i + 1);
-		t = str[j];
-		str[j] = str[i];
-		str[i] = t;
-	}
 }

--- a/rand_pure.c
+++ b/rand_pure.c
@@ -21,19 +21,24 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __RAND_H__
-#define __RAND_H__
+#include <stdio.h>
+#include "rand.h"
 
-#include <stdint.h>
-#include <stdlib.h>
+uint32_t random_uniform(uint32_t n)
+{
+	uint32_t x, max = 0xFFFFFFFF - (0xFFFFFFFF % n);
+	while ((x = random32()) >= max);
+	return x / (max / n);
+}
 
-// platform specific
-uint32_t random32(void);
-void random_buffer(uint8_t *buf, size_t len);
-int finalize_rand(void);
-
-// see rand_pure.h
-uint32_t random_uniform(uint32_t n);
-void random_permute(char *buf, size_t len);
-
-#endif
+void random_permute(char *str, size_t len)
+{
+	int i, j;
+	char t;
+	for (i = len - 1; i >= 1; i--) {
+		j = random_uniform(i + 1);
+		t = str[j];
+		str[j] = str[i];
+		str[i] = t;
+	}
+}


### PR DESCRIPTION
I wanted to be able to replace `random32()` and `random_buffer()` for my application but still use the other code that builds on them.