### PR TITLE
Reduce use of static memory, in favour of stack vars

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -126,7 +126,7 @@ int hdnode_from_xprv(uint32_t depth, uint32_t child_num, const uint8_t *chain_co
 
 int hdnode_from_seed(const uint8_t *seed, int seed_len, const char* curve, HDNode *out)
 {
-	static CONFIDENTIAL uint8_t I[32 + 32];
+	CONFIDENTIAL uint8_t I[32 + 32];
 	memset(out, 0, sizeof(HDNode));
 	out->depth = 0;
 	out->child_num = 0;
@@ -134,7 +134,7 @@ int hdnode_from_seed(const uint8_t *seed, int seed_len, const char* curve, HDNod
 	if (out->curve == 0) {
 		return 0;
 	}
-	static CONFIDENTIAL HMAC_SHA512_CTX ctx;
+	CONFIDENTIAL HMAC_SHA512_CTX ctx;
 	hmac_sha512_Init(&ctx, (const uint8_t*) out->curve->bip32_name, strlen(out->curve->bip32_name));
 	hmac_sha512_Update(&ctx, seed, seed_len);
 	hmac_sha512_Final(&ctx, I);
@@ -175,9 +175,9 @@ uint32_t hdnode_fingerprint(HDNode *node)
 
 int hdnode_private_ckd(HDNode *inout, uint32_t i)
 {
-	static CONFIDENTIAL uint8_t data[1 + 32 + 4];
-	static CONFIDENTIAL uint8_t I[32 + 32];
-	static CONFIDENTIAL bignum256 a, b;
+	CONFIDENTIAL uint8_t data[1 + 32 + 4];
+	CONFIDENTIAL uint8_t I[32 + 32];
+	CONFIDENTIAL bignum256 a, b;
 
 	if (i & 0x80000000) { // private derivation
 		data[0] = 0;
@@ -193,7 +193,7 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
 
 	bn_read_be(inout->private_key, &a);
 
-	static CONFIDENTIAL HMAC_SHA512_CTX ctx;
+	CONFIDENTIAL HMAC_SHA512_CTX ctx;
 	hmac_sha512_Init(&ctx, inout->chain_code, 32);
 	hmac_sha512_Update(&ctx, data, sizeof(data));
 	hmac_sha512_Final(&ctx, I);

--- a/bip39.c
+++ b/bip39.c
@@ -229,7 +229,7 @@ void mnemonic_to_seed(const char *mnemonic, const char *passphrase, uint8_t seed
 	uint8_t salt[8 + 256];
 	memcpy(salt, "mnemonic", 8);
 	memcpy(salt + 8, passphrase, passphraselen);
-	static CONFIDENTIAL PBKDF2_HMAC_SHA512_CTX pctx;
+	CONFIDENTIAL PBKDF2_HMAC_SHA512_CTX pctx;
 	pbkdf2_hmac_sha512_Init(&pctx, (const uint8_t *)mnemonic, strlen(mnemonic), salt, passphraselen + 8);
 	if (progress_callback) {
 		progress_callback(0, BIP39_PBKDF2_ROUNDS);

--- a/ecdsa.c
+++ b/ecdsa.c
@@ -434,13 +434,13 @@ void point_multiply(const ecdsa_curve *curve, const bignum256 *k, const curve_po
 	assert (bn_is_less(k, &curve->order));
 
 	int i, j;
-	static CONFIDENTIAL bignum256 a;
+	CONFIDENTIAL bignum256 a;
 	uint32_t *aptr;
 	uint32_t abits;
 	int ashift;
 	uint32_t is_even = (k->val[0] & 1) - 1;
 	uint32_t bits, sign, nsign;
-	static CONFIDENTIAL jacobian_curve_point jres;
+	CONFIDENTIAL jacobian_curve_point jres;
 	curve_point pmult[8];
 	const bignum256 *prime = &curve->prime;
 
@@ -555,10 +555,10 @@ void scalar_multiply(const ecdsa_curve *curve, const bignum256 *k, curve_point *
 	assert (bn_is_less(k, &curve->order));
 
 	int i, j;
-	static CONFIDENTIAL bignum256 a;
+	CONFIDENTIAL bignum256 a;
 	uint32_t is_even = (k->val[0] & 1) - 1;
 	uint32_t lowbits;
-	static CONFIDENTIAL jacobian_curve_point jres;
+	CONFIDENTIAL jacobian_curve_point jres;
 	const bignum256 *prime = &curve->prime;
 
 	// is_even = 0xffffffff if k is even, 0 otherwise.

--- a/hmac.c
+++ b/hmac.c
@@ -29,7 +29,7 @@
 
 void hmac_sha256_Init(HMAC_SHA256_CTX *hctx, const uint8_t *key, const uint32_t keylen)
 {
-	static CONFIDENTIAL uint8_t i_key_pad[SHA256_BLOCK_LENGTH];
+	CONFIDENTIAL uint8_t i_key_pad[SHA256_BLOCK_LENGTH];
 	memset(i_key_pad, 0, SHA256_BLOCK_LENGTH);
 	if (keylen > SHA256_BLOCK_LENGTH) {
 		sha256_Raw(key, keylen, i_key_pad);
@@ -62,7 +62,7 @@ void hmac_sha256_Final(HMAC_SHA256_CTX *hctx, uint8_t *hmac)
 
 void hmac_sha256(const uint8_t *key, const uint32_t keylen, const uint8_t *msg, const uint32_t msglen, uint8_t *hmac)
 {
-	static CONFIDENTIAL HMAC_SHA256_CTX hctx;
+	CONFIDENTIAL HMAC_SHA256_CTX hctx;
 	hmac_sha256_Init(&hctx, key, keylen);
 	hmac_sha256_Update(&hctx, msg, msglen);
 	hmac_sha256_Final(&hctx, hmac);
@@ -70,11 +70,11 @@ void hmac_sha256(const uint8_t *key, const uint32_t keylen, const uint8_t *msg, 
 
 void hmac_sha256_prepare(const uint8_t *key, const uint32_t keylen, uint32_t *opad_digest, uint32_t *ipad_digest)
 {
-	static CONFIDENTIAL uint32_t key_pad[SHA256_BLOCK_LENGTH/sizeof(uint32_t)];
+	CONFIDENTIAL uint32_t key_pad[SHA256_BLOCK_LENGTH/sizeof(uint32_t)];
 
 	MEMSET_BZERO(key_pad, sizeof(key_pad));
 	if (keylen > SHA256_BLOCK_LENGTH) {
-		static CONFIDENTIAL SHA256_CTX context;
+		CONFIDENTIAL SHA256_CTX context;
 		sha256_Init(&context);
 		sha256_Update(&context, key, keylen);
 		sha256_Final(&context, (uint8_t*)key_pad);
@@ -104,7 +104,7 @@ void hmac_sha256_prepare(const uint8_t *key, const uint32_t keylen, uint32_t *op
 
 void hmac_sha512_Init(HMAC_SHA512_CTX *hctx, const uint8_t *key, const uint32_t keylen)
 {
-	static CONFIDENTIAL uint8_t i_key_pad[SHA512_BLOCK_LENGTH];
+	CONFIDENTIAL uint8_t i_key_pad[SHA512_BLOCK_LENGTH];
 	memset(i_key_pad, 0, SHA512_BLOCK_LENGTH);
 	if (keylen > SHA512_BLOCK_LENGTH) {
 		sha512_Raw(key, keylen, i_key_pad);
@@ -145,11 +145,11 @@ void hmac_sha512(const uint8_t *key, const uint32_t keylen, const uint8_t *msg, 
 
 void hmac_sha512_prepare(const uint8_t *key, const uint32_t keylen, uint64_t *opad_digest, uint64_t *ipad_digest)
 {
-	static CONFIDENTIAL uint64_t key_pad[SHA512_BLOCK_LENGTH/sizeof(uint64_t)];
+	CONFIDENTIAL uint64_t key_pad[SHA512_BLOCK_LENGTH/sizeof(uint64_t)];
 
 	MEMSET_BZERO(key_pad, sizeof(key_pad));
 	if (keylen > SHA512_BLOCK_LENGTH) {
-		static CONFIDENTIAL SHA512_CTX context;
+		CONFIDENTIAL SHA512_CTX context;
 		sha512_Init(&context);
 		sha512_Update(&context, key, keylen);
 		sha512_Final(&context, (uint8_t*)key_pad);


### PR DESCRIPTION
Removed static declarations for a few things that although confidential, should be on the stack because they are not needed between calls. If your `CONFIDENTIAL` macro (attributes?) requires use of static memory, then it should include the `static` keyword.

This change saved my project ~2,300 bytes of RAM.

It needs a good review before merging as I am not setup to run the tests.