### PR TITLE
bip32/nem: IV is copied before encryption

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -478,7 +478,7 @@ int hdnode_get_nem_shared_key(const HDNode *node, const ed25519_public_key peer_
 	return 1;
 }
 
-int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key, uint8_t *iv, const uint8_t *salt, const uint8_t *payload, size_t size, uint8_t *buffer) {
+int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key, const uint8_t *iv_immut, const uint8_t *salt, const uint8_t *payload, size_t size, uint8_t *buffer) {
 	uint8_t last_block[AES_BLOCK_SIZE];
 	uint8_t remainder = size % AES_BLOCK_SIZE;
 
@@ -488,6 +488,10 @@ int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key, 
 	memcpy(last_block, &payload[size], remainder);
 	// Pad new last block with number of missing bytes
 	memset(&last_block[remainder], AES_BLOCK_SIZE - remainder, AES_BLOCK_SIZE - remainder);
+
+	// the IV gets mutated, so we make a copy not to touch the original
+	uint8_t iv[AES_BLOCK_SIZE];
+	memcpy(iv, iv_immut, AES_BLOCK_SIZE);
 
 	uint8_t shared_key[SHA3_256_DIGEST_LENGTH];
 	if (!hdnode_get_nem_shared_key(node, public_key, salt, NULL, shared_key)) {

--- a/bip32.h
+++ b/bip32.h
@@ -77,7 +77,7 @@ int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash);
 #if USE_NEM
 int hdnode_get_nem_address(HDNode *node, uint8_t version, char *address);
 int hdnode_get_nem_shared_key(const HDNode *node, const ed25519_public_key peer_public_key, const uint8_t *salt, ed25519_public_key mul, uint8_t *shared_key);
-int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key, uint8_t *iv, const uint8_t *salt, const uint8_t *payload, size_t size, uint8_t *buffer);
+int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key, const uint8_t *iv, const uint8_t *salt, const uint8_t *payload, size_t size, uint8_t *buffer);
 int hdnode_nem_decrypt(const HDNode *node, const ed25519_public_key public_key, uint8_t *iv, const uint8_t *salt, const uint8_t *payload, size_t size, uint8_t *buffer);
 #endif
 


### PR DESCRIPTION
After merged this can be removed from mcu https://github.com/trezor/trezor-mcu/blob/master/firmware/nem2.c#L267-L269

cc @saleemrashid 
