### PR TITLE
bip39.c: optional API to avoid static vars, make mnemonic_generate optional

### DIFF
--- a/bip39.c
+++ b/bip39.c
@@ -22,7 +22,6 @@
  */
 
 #include <string.h>
-#include <stdbool.h>
 
 #include "bip39.h"
 #include "hmac.h"

--- a/bip39.c
+++ b/bip39.c
@@ -46,6 +46,7 @@ static CONFIDENTIAL struct {
 
 #endif
 
+#if USE_BIP39_GENERATE
 const char *mnemonic_generate(int strength)
 {
 	if (strength % 32 || strength < 128 || strength > 256) {
@@ -69,11 +70,23 @@ const uint16_t *mnemonic_generate_indexes(int strength)
 	memzero(data, sizeof(data));
 	return r;
 }
+#endif
 
 const char *mnemonic_from_data(const uint8_t *data, int len)
 {
+	static CONFIDENTIAL char mnemo[24 * 10];
+
+    if(mnemonic_from_data_p(data, len, mnemo)) {
+        return mnemo;
+    } else {
+        return 0;
+    }
+}
+
+bool mnemonic_from_data_p(const uint8_t *data, int len, char mnemo[240])
+{
 	if (len % 4 || len < 16 || len > 32) {
-		return 0;
+		return false;
 	}
 
 	uint8_t bits[32 + 1];
@@ -85,7 +98,6 @@ const char *mnemonic_from_data(const uint8_t *data, int len)
 	memcpy(bits, data, len);
 
 	int mlen = len * 3 / 4;
-	static CONFIDENTIAL char mnemo[24 * 10];
 
 	int i, j, idx;
 	char *p = mnemo;
@@ -102,13 +114,24 @@ const char *mnemonic_from_data(const uint8_t *data, int len)
 	}
 	memzero(bits, sizeof(bits));
 
-	return mnemo;
+    return true;
 }
 
 const uint16_t *mnemonic_from_data_indexes(const uint8_t *data, int len)
 {
+	static CONFIDENTIAL uint16_t mnemo[24];
+
+    if(mnemonic_from_data_indexes_p(data, len, mnemo)) {
+        return mnemo;
+    } else {
+        return 0;
+    }
+}
+
+bool mnemonic_from_data_indexes_p(const uint8_t *data, int len, uint16_t mnemo[24])
+{
 	if (len % 4 || len < 16 || len > 32) {
-		return 0;
+		return false;
 	}
 
 	uint8_t bits[32 + 1];
@@ -120,7 +143,6 @@ const uint16_t *mnemonic_from_data_indexes(const uint8_t *data, int len)
 	memcpy(bits, data, len);
 
 	int mlen = len * 3 / 4;
-	static CONFIDENTIAL uint16_t mnemo[24];
 
 	int i, j, idx;
 	for (i = 0; i < mlen; i++) {
@@ -133,7 +155,7 @@ const uint16_t *mnemonic_from_data_indexes(const uint8_t *data, int len)
 	}
 	memzero(bits, sizeof(bits));
 
-	return mnemo;
+    return true;
 }
 
 int mnemonic_check(const char *mnemonic)

--- a/bip39.h
+++ b/bip39.h
@@ -32,7 +32,10 @@ const char *mnemonic_generate(int strength);	// strength in bits
 const uint16_t *mnemonic_generate_indexes(int strength);	// strength in bits
 
 const char *mnemonic_from_data(const uint8_t *data, int len);
+bool mnemonic_from_data_p(const uint8_t *data, int len, char mnemo[240]);
+
 const uint16_t *mnemonic_from_data_indexes(const uint8_t *data, int len);
+bool mnemonic_from_data_indexes_p(const uint8_t *data, int len, uint16_t mnemo[24]);
 
 int mnemonic_check(const char *mnemonic);
 

--- a/bip39.h
+++ b/bip39.h
@@ -25,6 +25,7 @@
 #define __BIP39_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define BIP39_PBKDF2_ROUNDS 2048
 

--- a/options.h
+++ b/options.h
@@ -56,6 +56,11 @@
 #define BIP39_CACHE_SIZE 4
 #endif
 
+// include generate code (requires 240 bytes BSS, random_buffer() function)
+#ifndef USE_BIP39_GENERATE
+#define USE_BIP39_GENERATE 1
+#endif
+
 // support Ethereum operations
 #ifndef USE_ETHEREUM
 #define USE_ETHEREUM 0


### PR DESCRIPTION
As discussed in #136, this creates new entry points where the output buffer is provided as a pointer to caller's memory. I've also included compatibility code that matches the operation of the old code.

The new function names have `_p` suffix. The version with internal static memory retains the old name.

```
mnemonic_from_data_p()
mnemonic_from_data()
mnemonic_from_data_indexes()
mnemonic_from_data_indexes_p()
```

I didn't follow through with corresponding changes to `mnemonic_generate()` so I made it optional.

This change saves 272 bytes of RAM, if you use the `_p` versions and avoid linking the other versions of these functions.