### PR TITLE
bip32, options: optionally exclude 25519 curves in BIP32 support

### DIFF
--- a/bip32.c
+++ b/bip32.c
@@ -421,6 +421,8 @@ void hdnode_fill_public_key(HDNode *node)
 {
 	if (node->public_key[0] != 0)
 		return;
+
+#if USE_BIP32_25519_CURVES
 	if (node->curve->params) {
 		ecdsa_get_public_key33(node->curve->params, node->private_key, node->public_key);
 	} else {
@@ -437,6 +439,10 @@ void hdnode_fill_public_key(HDNode *node)
 			curve25519_scalarmult_basepoint(node->public_key + 1, node->private_key);
 		}
 	}
+#else
+
+    ecdsa_get_public_key33(node->curve->params, node->private_key, node->public_key);
+#endif
 }
 
 #if USE_ETHEREUM

--- a/options.h
+++ b/options.h
@@ -50,6 +50,11 @@
 #define BIP32_CACHE_MAXDEPTH 8
 #endif
 
+// support constructing BIP32 nodes from ed25519 and curve25519 curves.
+#ifndef USE_BIP32_25519_CURVES
+#define USE_BIP32_25519_CURVES    1
+#endif
+
 // implement BIP39 caching
 #ifndef USE_BIP39_CACHE
 #define USE_BIP39_CACHE 1


### PR DESCRIPTION
I wanted to compile without all the 25519 curve stuff, so I had to add this configuration value.