### PR TITLE
Fix RFC 7539 padding

### DIFF
--- a/chacha20poly1305/rfc7539.c
+++ b/chacha20poly1305/rfc7539.c
@@ -26,7 +26,8 @@ void rfc7539_init(chacha20poly1305_ctx *ctx, uint8_t key[32], uint8_t nonce[12])
 void rfc7539_auth(chacha20poly1305_ctx *ctx, uint8_t *in, size_t n) {
     uint8_t padding[16] = {0};
     poly1305_update(&ctx->poly1305, in, n);
-    poly1305_update(&ctx->poly1305, padding, 16 - n%16);
+    if (n % 16 != 0)
+        poly1305_update(&ctx->poly1305, padding, 16 - n%16);
 }
 
 // Compute RFC 7539-style Poly1305 MAC.
@@ -37,7 +38,8 @@ void rfc7539_finish(chacha20poly1305_ctx *ctx, int64_t alen, int64_t plen, uint8
     memcpy(lengths, &alen, sizeof(int64_t));
     memcpy(lengths + 8, &plen, sizeof(int64_t));
 
-    poly1305_update(&ctx->poly1305, padding, 16 - plen%16);
+    if (plen % 16 != 0)
+        poly1305_update(&ctx->poly1305, padding, 16 - plen%16);
     poly1305_update(&ctx->poly1305, lengths, 16);
 
     poly1305_finish(&ctx->poly1305, mac);


### PR DESCRIPTION
According to RFC 7539 there's no padding when associated data or plaintext is a multiple of 16.