### PR TITLE
Allow to compile without Valgrind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ CFLAGS   += $(OPTFLAGS) \
             -Wformat-security \
             -Werror
 
+VALGRIND ?= 1
+
 CFLAGS += -I.
+CFLAGS += -DVALGRIND=$(VALGRIND)
 CFLAGS += -DUSE_ETHEREUM=1
 CFLAGS += -DUSE_GRAPHENE=1
 CFLAGS += -DUSE_NEM=1

--- a/tests/test_check.c
+++ b/tests/test_check.c
@@ -31,8 +31,10 @@
 #include <check.h>
 #include "check_mem.h"
 
+#if VALGRIND
 #include <valgrind/valgrind.h>
 #include <valgrind/memcheck.h>
+#endif
 
 #include "options.h"
 
@@ -62,6 +64,7 @@
 #include "rc4.h"
 #include "nem.h"
 
+#if VALGRIND
 /*
  * This is a clever trick to make Valgrind's Memcheck verify code
  * is constant-time with respect to secret data.
@@ -71,6 +74,10 @@
 #define   MARK_SECRET_DATA(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
 /* Call before secret data is freed or to mark non-secret data (public keys or signatures) */
 #define UNMARK_SECRET_DATA(addr, len) VALGRIND_MAKE_MEM_DEFINED  (addr, len)
+#else
+#define   MARK_SECRET_DATA(addr, len)
+#define UNMARK_SECRET_DATA(addr, len)
+#endif
 
 #define FROMHEX_MAXLEN 512
 


### PR DESCRIPTION
Allow to compile without Valgrind using

```bash
NO_VALGRIND=1 make
```

In some configurations having Valgrind functional can be a problem, e.g., OSX 10.13 (http://www.valgrind.org/downloads/current.html#current) which makes development and testing a bit problematic. Having the possibility to disable Valgrind check would be therefore nice.