### PR TITLE
Provide shared lib target using libsodium random generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ OBJS   = $(SRCS:.c=.o)
 TESTLIBS = $(shell pkg-config --libs check) -lpthread -lm
 TESTSSLLIBS = $(shell pkg-config --libs openssl)
 
+LIBTARGETFLAGS = -DUSE_LIBSODIUM=1
+LIBTARGETFLAGS += -DSODIUM_STATIC=1
+LIBTARGETFLAGS += -DRAND_PLATFORM_INDEPENDENT=1
+LIBTARGETFLAGS += $(shell pkg-config --cflags libsodium)
+LIBTARGETLIBS = $(shell pkg-config --libs libsodium)
+
 all: tools tests
 
 %.o: %.c %.h options.h
@@ -95,6 +101,11 @@ tools/mktable: tools/mktable.o $(OBJS)
 
 tools/bip39bruteforce: tools/bip39bruteforce.o $(OBJS)
 	$(CC) tools/bip39bruteforce.o $(OBJS) -o tools/bip39bruteforce
+
+lib: libtrezor-crypto.so
+
+libtrezor-crypto.so: $(SRCS)
+	$(CC) $(CFLAGS) $(LIBTARGETFLAGS) -fPIC -shared $(SRCS) $(LIBTARGETLIBS) -o libtrezor-crypto.so
 
 clean:
 	rm -f *.o aes/*.o chacha20poly1305/*.o ed25519-donna/*.o

--- a/rand.c
+++ b/rand.c
@@ -50,6 +50,30 @@ uint32_t random32(void)
 
 #endif /* RAND_PLATFORM_INDEPENDENT */
 
+#if defined(USE_LIBSODIUM) && USE_LIBSODIUM
+
+#include <sodium.h>
+
+int random_init(void){
+  return sodium_init();
+}
+
+uint32_t random32(void)
+{
+  return randombytes_random();
+}
+
+void __attribute__((weak)) random_buffer(uint8_t *buf, size_t len)
+{
+  randombytes_buf(buf, len);
+}
+
+uint32_t random_uniform(uint32_t n)
+{
+  return randombytes_uniform(n);
+}
+#else
+
 //
 // The following code is platform independent
 //
@@ -71,6 +95,8 @@ uint32_t random_uniform(uint32_t n)
 	while ((x = random32()) >= max);
 	return x / (max / n);
 }
+
+#endif /* !USE_LIBSODIUM */
 
 void random_permute(char *str, size_t len)
 {

--- a/rand.h
+++ b/rand.h
@@ -33,4 +33,8 @@ void random_buffer(uint8_t *buf, size_t len);
 uint32_t random_uniform(uint32_t n);
 void random_permute(char *buf, size_t len);
 
+#if defined(USE_LIBSODIUM) && USE_LIBSODIUM
+int random_init(void);
+#endif
+
 #endif


### PR DESCRIPTION
The Trezor-crypto became a nice collection of cryptocurrency-related code that might be also useful as a shared library. 

In fact, I use it in some projects and the only thing missing to make it a fully usable shared library without any gluing code is a random number generator. 

One way is to define `RAND_PLATFORM_INDEPENDENT` and provide a custom function in the gluing code

```cpp
uint32_t random32(void)
```

This requires additional code and makefile.

Another way is to add a lib target and use random number generator provided by some lightweight (small number of deps) cryptographic library, such as libsodium.

This PR implements the latter way. It is a draft and you may want to do it differently.