### PR TITLE
Fix decred bip32 name

### DIFF
--- a/secp256k1.c
+++ b/secp256k1.c
@@ -65,7 +65,7 @@ const curve_info secp256k1_info = {
 };
 
 const curve_info secp256k1_decred_info = {
-	.bip32_name = "Decred seed",
+	.bip32_name = "Bitcoin seed",
 	.params = &secp256k1,
 	.hasher_bip32 = HASHER_BLAKE,
 	.hasher_base58 = HASHER_BLAKED,


### PR DESCRIPTION
Standard decred software uses `Bitcoin seed` instead of `Decred seed` as the bip32 master key[1][2]. 

Ideally, trezor should use the same master key as standard decred software to allow better interoperability; in particular to allow users to import their trezor seed (after a small conversion) into standard decred software.

While this breaks any existing decred trezor wallets, no software has been officially released to allow using decred with trezor. Neither trezor web wallet nor any decred wallet has been released to the general public yet. We can also provide a recovery path for any outstanding trezor users that might have already used the recently released firmware 1.6.2 with mainnet decred coins.

We'll need to have this fix applied then wait for the next round of firmware updates to be released before releasing official decred wallets with trezor support.

[1] https://github.com/decred/dcrd/blob/master/hdkeychain/extendedkey.go#L97
[2] https://github.com/decred/dcrd/blob/master/hdkeychain/extendedkey.go#L464