### PR TITLE
ed25519: scalarmult fix so dst can be src

### DIFF
--- a/ed25519-donna/ed25519-donna-impl-base.c
+++ b/ed25519-donna/ed25519-donna-impl-base.c
@@ -421,12 +421,12 @@ void ge25519_scalarmult(ge25519 *r, const ge25519 *p1, const bignum256modm s1) {
 
 	contract256_window4_modm(slide1, s1);
 
-	/* set neutral */
-	ge25519_set_neutral(r);
-
-	ge25519_full_to_pniels(pre1, r);
 	ge25519_full_to_pniels(pre1+1, p1);
 	ge25519_double(&d1, p1);
+
+	ge25519_set_neutral(r);
+	ge25519_full_to_pniels(pre1, r);
+
 	ge25519_full_to_pniels(pre1+2, &d1);
 	for (i = 1; i < 7; i++) {
 		ge25519_pnielsadd(&pre1[i+2], &d1, &pre1[i]);
@@ -443,6 +443,7 @@ void ge25519_scalarmult(ge25519 *r, const ge25519 *p1, const bignum256modm s1) {
 		ge25519_pnielsadd_p1p1(&t, r, &pre, (unsigned char)slide1[i] >> 7);
 		ge25519_p1p1_to_partial(r, &t);
 	}
+	curve25519_mul(r->t, t.x, t.y);
 }
 
 void ge25519_scalarmult_base_choose_niels(ge25519_niels *t, const uint8_t table[256][96], uint32_t pos, signed char b) {


### PR DESCRIPTION
`ge25519_scalarmult` minor changes:

- Result `r` can be equal to the input `p1` (same point pointer).
- Returns fully valid extended Edwards point (not partial as before). 
  - Makes further operations easier because many operations expect full point (with valid `T` coordinate), not the partial. 
  - `ge25519_scalarmult_base_niels` already returns full point so it would make it more consistent
  - Scalar multiplications perform large number of `curve25519_mul`, typically `(64*const)`, one more before returning from the function is IMO small overhead.
  - if `ge25519_scalarmult` returns partial point one cannot easily make it full point because after `ge25519_scalarmult` returns, the temporary point is not not accessible. To make it full point much more expensive inversion would be needed. 
