### PR TITLE
ed25519: double scalarmult fix - return full point

### DIFF
--- a/ed25519-donna/ed25519-donna-impl-base.c
+++ b/ed25519-donna/ed25519-donna-impl-base.c
@@ -243,6 +243,7 @@ void ge25519_double_scalarmult_vartime(ge25519 *r, const ge25519 *p1, const bign
 	ge25519_p1p1 t;
 	int32_t i;
 
+	memset(&t, 0, sizeof(ge25519_p1p1));
 	contract256_slidingwindow_modm(slide1, s1, S1_SWINDOWSIZE);
 	contract256_slidingwindow_modm(slide2, s2, S2_SWINDOWSIZE);
 
@@ -283,6 +284,7 @@ void ge25519_double_scalarmult_vartime(ge25519 *r, const ge25519 *p1, const bign
 
 		ge25519_p1p1_to_partial(r, &t);
 	}
+	curve25519_mul(r->t, t.x, t.y);
 }
 
 /* computes [s1]p1 + [s2]p2 */
@@ -295,6 +297,7 @@ void ge25519_double_scalarmult_vartime2(ge25519 *r, const ge25519 *p1, const big
 	ge25519_p1p1 t;
 	int32_t i;
 
+	memset(&t, 0, sizeof(ge25519_p1p1));
 	contract256_slidingwindow_modm(slide1, s1, S1_SWINDOWSIZE);
 	contract256_slidingwindow_modm(slide2, s2, S1_SWINDOWSIZE);
 
@@ -329,6 +332,7 @@ void ge25519_double_scalarmult_vartime2(ge25519 *r, const ge25519 *p1, const big
 
 		ge25519_p1p1_to_partial(r, &t);
 	}
+	curve25519_mul(r->t, t.x, t.y);
 }
 #endif
 


### PR DESCRIPTION
Double scalar multiplication returns fully valid ED point (Just one more multiplication).
  - Makes further operations easier because many operations expect full point (with valid `T` coordinate), not the partial. 
  - `ge25519_scalarmult_base_niels` already returns full point so it would make it more consistent
  - Scalar multiplications perform a large number of `curve25519_mul`, typically `(64*const)`, one more before returning from the function is IMO small overhead.
  - if `ge25519_scalarmult` returns partial point one cannot easily make it the full point because after `ge25519_scalarmult` returns, the temporary point is not accessible. To make it full point much more expensive inversion would be needed.

If you prefer not to add multiplication there is another alternative - a bit more difficult IMO. We would have to generalize scalarmult method to return `ge25519_p1p1` point so we can make it both partial and full points. There would be then scalarmult method which is a simple wrapper for scalarmult returning `ge25519_p1p1` and making a partial point from it. 

I personally like the proposed idea more because it is backward compatible change with small overhead, is consistent with scalarmult base and does not make API more complex.