### PR TITLE
ed25519: ROTR, ROTL removed from header file

### DIFF
--- a/ed25519-donna/ed25519-donna-portable.h
+++ b/ed25519-donna/ed25519-donna-portable.h
@@ -7,8 +7,6 @@
 #define DONNA_INLINE
 #undef ALIGN
 #define ALIGN(x) __attribute__((aligned(x)))
-#define ROTL32(a,b) (((a) << (b)) | ((a) >> (32 - b)))
-#define ROTR32(a,b) (((a) >> (b)) | ((a) << (32 - b)))
 
 static inline void U32TO8_LE(unsigned char *p, const uint32_t v) {
 	p[0] = (unsigned char)(v      );


### PR DESCRIPTION
- redundant, not used in trezor-crypto
- clashes with another ROTR macro from poly1305 header file if included together