### PR TITLE
Generate bip39 seeds on the CLI via bip39_mnemonic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ tests/test_openssl: tests/test_openssl.o $(OBJS)
 tests/libtrezor-crypto.so: $(SRCS)
 	$(CC) $(CFLAGS) -DAES_128 -DAES_192 -fPIC -shared $(SRCS) -o tests/libtrezor-crypto.so
 
-tools: tools/xpubaddrgen tools/mktable tools/bip39bruteforce
+tools: tools/xpubaddrgen tools/mktable tools/bip39bruteforce tools/bip39_mnemonic
 
 tools/xpubaddrgen: tools/xpubaddrgen.o $(OBJS)
 	$(CC) tools/xpubaddrgen.o $(OBJS) -o tools/xpubaddrgen
@@ -104,7 +104,10 @@ tools/mktable: tools/mktable.o $(OBJS)
 tools/bip39bruteforce: tools/bip39bruteforce.o $(OBJS)
 	$(CC) tools/bip39bruteforce.o $(OBJS) -o tools/bip39bruteforce
 
+tools/bip39_mnemonic: tools/bip39_mnemonic.o $(OBJS)
+	$(CC) tools/bip39_mnemonic.o $(OBJS) -o tools/bip39_mnemonic -lsodium
+
 clean:
 	rm -f *.o aes/*.o chacha20poly1305/*.o ed25519-donna/*.o
 	rm -f tests/test_check tests/test_speed tests/test_openssl tests/libtrezor-crypto.so tests/aestst
-	rm -f tools/*.o tools/xpubaddrgen tools/mktable tools/bip39bruteforce
+	rm -f tools/*.o tools/xpubaddrgen tools/mktable tools/bip39bruteforce tools/bip39_mnemonic

--- a/tools/bip39_mnemonic.c
+++ b/tools/bip39_mnemonic.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include "bip39.h"
+#include <sodium.h>
+
+// NOTE: We must override this to implement actual RNG!
+void random_buffer(uint8_t *buf, size_t len) {
+    if( len > 0 ) {
+        randombytes_buf(buf, len);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    char *this = argv[0];
+    if (argc > 1) {
+        fprintf(stderr, "Usage: %s\n", this);
+        return 1;
+    }
+    if (sodium_init() == -1) {
+        fprintf(stderr, "libsodium init failed! :(\n");
+        return 1;
+    }
+    int strength = 256;
+    const char *mnemonic = mnemonic_generate(strength);
+    printf("%s\n", mnemonic);
+    return 0;
+}


### PR DESCRIPTION
I wrote this tool for my own use and it is a nice example of using trezor-crypto to write a real application with real RNG. I figured you might want it as an example in the repo, but I understand if not.

libsodium `randombytes_buf` is used for RNG
